### PR TITLE
Werkzeuge aus GitHub Repositories dokumentiert

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,7 +15,32 @@ Diese Dokumentation dient als zentrale Anlaufstelle für KI-Agenten, um Werkzeug
 - **Inhalte:** Jedes Werkzeug wird mit Name, Zweck, Referenzhandbuch, Installationsbefehle in der Tabelle geführt
 - **Installierbarkeit:** Vor der Aufnahme in die Liste wird die Software auf Installierbarkeit geprüft.
 
-#### Datenqullen/-sammlungen
+| Name | Zweck | Referenzhandbuch | Installationsbefehle |
+| :--- | :--- | :--- | :--- |
+| vLLM | LLM Inferenz-Engine | [Link](https://github.com/vllm-project/vllm) | `pip install vllm` |
+| Vast.ai SDK | Management von GPU-Instanzen | [Link](https://github.com/Vast-ai/vast-python) | `pip install vastai` |
+| Pawn Compiler | Skriptsprache für Embedded Systems | [Link](https://github.com/compuphase/pawn) | - |
+| Blockly | Visuelle Programmierung | [Link](https://developers.google.com/blockly) | `npm install blockly` |
+| Renode | Emulator für Hardware-Systeme | [Link](https://renode.io/) | [Download](https://renode.io/#download) |
+| Playwright | E2E Testing für Webanwendungen | [Link](https://playwright.dev/) | `npm install playwright` |
+| MCP-FreeCAD | Model Context Protocol für FreeCAD | [Link](https://github.com/jango-blockchained/mcp-freecad) | - |
+| MeshLab | Bearbeitung von 3D-Meshes | [Link](https://www.meshlab.net/) | `sudo apt install meshlab` |
+| KiBot | Automatisierung für KiCAD | [Link](https://github.com/INTI-CMNB/KiBot) | `pip install kibot` |
+| SKiDL | Schaltungsentwurf in Python | [Link](https://devbisme.github.io/skidl/) | `pip install skidl` |
+| Apache FOP | Print Formatter für XSL-FO | [Link](https://xmlgraphics.apache.org/fop/) | `sudo apt install fop` |
+| Ollama | Lokaler Betrieb von LLMs | [Link](https://ollama.com/) | `curl -fsSL https://ollama.com/install.sh \| sh` |
+| WaveDrom | Zeitdiagramm-Renderer | [Link](https://wavedrom.com/) | `npm install wavedrom` |
+
+#### Datenquellen/-sammlungen
 - **Format:** Die Datensammlungen werden ebenfalls in Tabellenform dokumentiert.
 - **Inhalte:** Jedes Sammlung wird mit Name, Zweck, Referenzhandbuch sowie Zugriffarten zum Beschaffung und/oder Abfrage beschrieben
 - **Abfragbarkeit:** Vor der Aufnahme in die Liste wird die Software auf Installierbarkeit geprüft.
+
+| Name | Zweck | Referenzhandbuch | Zugriff / Abfrage |
+| :--- | :--- | :--- | :--- |
+| GitHub API | Repository- und Issue-Daten | [Link](https://docs.github.com/en/rest) | REST / GraphQL API |
+| Google Jules | Interner Task-Status | - | API-Integration |
+| Hugging Face | Modell-Repository | [Link](https://huggingface.co/) | `huggingface-cli download` |
+| IHP Open PDK | Open Source PDK (130nm) | [Link](https://github.com/IHP-GmbH/IHP-Open-PDK) | git clone |
+| ISO 20022 camt.053 | Bankkontoauszüge | - | XML Import |
+| eCH-0196 | Schweizer Steuerauszug | - | XML Import |


### PR DESCRIPTION
Ich habe die 20 zuletzt verwendeten GitHub Repositories von chatelao durchsucht und die darin enthaltenen oder verwendeten Werkzeuge und Datenquellen identifiziert. Diese wurden strukturiert in die zentrale Dokumentationsdatei `GEMINI.md` aufgenommen. Zu den gefundenen Werkzeugen gehören unter anderem KI-Inferenz-Engines (vLLM, Ollama), Hardware-Emulatoren (Renode), Design-Tools (KiBot, SKiDL, MeshLab) und Test-Frameworks (Playwright, WaveDrom). Als Datenquellen wurden Schnittstellen wie die GitHub API, Google Jules und Sammlungen wie das IHP Open PDK erfasst. Die Dokumentation erfolgt in deutscher Sprache und im Tabellenformat, wie in der Strategie festgelegt.

Fixes #3

---
*PR created automatically by Jules for task [6650258691307163060](https://jules.google.com/task/6650258691307163060) started by @chatelao*