### PR TITLE
Add CircuiTikZ to toolings

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -19,3 +19,9 @@ Diese Dokumentation dient als zentrale Anlaufstelle für KI-Agenten, um Werkzeug
 - **Format:** Die Datensammlungen werden ebenfalls in Tabellenform dokumentiert.
 - **Inhalte:** Jedes Sammlung wird mit Name, Zweck, Referenzhandbuch sowie Zugriffarten zum Beschaffung und/oder Abfrage beschrieben
 - **Abfragbarkeit:** Vor der Aufnahme in die Liste wird die Software auf Installierbarkeit geprüft.
+
+## 2. Liste der Werkzeuge
+
+| Name | Zweck | Referenzhandbuch | Installationsbefehle |
+| :--- | :--- | :--- | :--- |
+| CircuiTikZ | TeX/LaTeX-Paket zum Zeichnen von elektrischen Schaltungen | [Handbuch](https://mirror.init7.net/ctan/graphics/pgf/contrib/circuitikz/doc/circuitikzmanual.pdf) | `sudo apt-get install texlive-pictures` |


### PR DESCRIPTION
Added the CircuiTikZ manual to the tools documentation in GEMINI.md.
Identified the correct Ubuntu package (texlive-pictures) and included
the manual link and installation command as per the repository strategy.

Fixes #4

---
*PR created automatically by Jules for task [16493795438818465086](https://jules.google.com/task/16493795438818465086) started by @chatelao*