### PR TITLE
Add Wikidata (SPARQL) and Overpass Turbo to data sources

### DIFF
--- a/DATASOURCES.md
+++ b/DATASOURCES.md
@@ -4,8 +4,10 @@
 | :--- | :--- | :--- | :--- | :--- |
 | Finanzen | eCH-0196 | Schweizer Steuerauszug | XML Import | - |
 | Finanzen | ISO 20022 camt.053 | Bankkontoauszüge | XML Import | - |
+| Geodaten | Overpass Turbo | Webbasiertes Datensammelwerkzeug für OpenStreetMap | Overpass API / Web-GUI | [Link](https://wiki.openstreetmap.org/wiki/DE:Overpass_turbo) |
 | Hardware/EDA | CircuiTikZ | TeX/LaTeX-Paket zum Zeichnen von elektrischen Schaltungen | `sudo apt-get install texlive-pictures` | [Handbuch](https://mirror.init7.net/ctan/graphics/pgf/contrib/circuitikz/doc/circuitikzmanual.pdf) |
 | Hardware/EDA | IHP Open PDK | Open Source PDK (130nm) | git clone | [Link](https://github.com/IHP-GmbH/IHP-Open-PDK) |
 | KI-Modelle | Hugging Face | Modell-Repository | `huggingface-cli download` | [Link](https://huggingface.co/) |
 | Projekt-Management | Google Jules | Interner Task-Status | API-Integration | - |
 | Software-Entwicklung | GitHub API | Repository- und Issue-Daten | REST / GraphQL API | [Link](https://docs.github.com/en/rest) |
+| Wissen | Wikidata (SPARQL) | Semantische Abfragesprache für die Wikidata-Wissensdatenbank | SPARQL Endpunkt / Web-GUI | [Link](https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/de) |


### PR DESCRIPTION
This PR adds two powerful data sources to the AI tooling documentation:
1. **Overpass Turbo**: A web-based data filtering tool for OpenStreetMap (Geodaten).
2. **Wikidata (SPARQL)**: A semantic query language for the Wikidata knowledge base (Wissen).

Both entries include their purpose (Zweck), access methods (Zugriff), and reference manuals (Referenzhandbuch) in German, adhering to the project's documentation standards and alphabetical organization.

Fixes #12

---
*PR created automatically by Jules for task [13589000853582292875](https://jules.google.com/task/13589000853582292875) started by @chatelao*