### PR TITLE
Add KiCad 10.0 installation to TOOLS.md

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -8,6 +8,7 @@
 | Dokumentation | PlantUML | UML-Diagramm-Renderer | `sudo apt install plantuml` | [Link](https://plantuml.com/) |
 | Dokumentation | WaveDrom | Zeitdiagramm-Renderer | `npm install wavedrom` | [Link](https://wavedrom.com/) |
 | EDA | KiBot | Automatisierung für KiCAD | `pip install kibot` | [Link](https://github.com/INTI-CMNB/KiBot) |
+| EDA | KiCad 10.0 | Elektronik-Design-Automatisierung | `sudo add-apt-repository ppa:kicad/kicad-10.0-releases; sudo apt update; sudo apt install --install-recommends kicad` | [Link](https://www.kicad.org/) |
 | EDA | SKiDL | Schaltungsentwurf in Python | `pip install skidl` | [Link](https://devbisme.github.io/skidl/) |
 | Hardware-Simulation | Renode | Emulator für Hardware-Systeme | [Download](https://renode.io/#download) | [Link](https://renode.io/) |
 | Infrastruktur | Vast.ai SDK | Management von GPU-Instanzen | `pip install vastai` | [Link](https://github.com/Vast-ai/vast-python) |


### PR DESCRIPTION
Added KiCad 10.0 to `TOOLS.md` with its purpose, installation commands (using the official PPA), and reference link. Verified the change and ensured alphabetical order in the EDA group.

Fixes #15

---
*PR created automatically by Jules for task [3918831004178706012](https://jules.google.com/task/3918831004178706012) started by @chatelao*