### PR TITLE
Add OpenAPI Generator to TOOLS.md

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -14,5 +14,6 @@
 | KI-Inferenz | Ollama | Lokaler Betrieb von LLMs | `curl -fsSL https://ollama.com/install.sh \| sh` | [Link](https://ollama.com/) |
 | KI-Inferenz | vLLM | LLM Inferenz-Engine | `pip install vllm` | [Link](https://github.com/vllm-project/vllm) |
 | Programmierung | Blockly | Visuelle Programmierung | `npm install blockly` | [Link](https://developers.google.com/blockly) |
+| Programmierung | OpenAPI Generator | Generierung von API-Clients, Server-Stubs und Dokumentation aus OpenAPI-Spezifikationen | `npm install @openapitools/openapi-generator-cli` | [Link](https://openapi-generator.tech/) |
 | Programmierung | Pawn Compiler | Skriptsprache für Embedded Systems | - | [Link](https://github.com/compuphase/pawn) |
 | Testing | Playwright | E2E Testing für Webanwendungen | `npm install playwright` | [Link](https://playwright.dev/) |


### PR DESCRIPTION
I have added the OpenAPI Generator to the `TOOLS.md` file. 

Key changes:
- Added a new entry for "OpenAPI Generator" under the "Programmierung" group.
- Maintained the alphabetical order within the group (Blockly < OpenAPI Generator < Pawn Compiler).
- Provided the installation command using the recommended npm package (`@openapitools/openapi-generator-cli`).
- Included the link to the official documentation (https://openapi-generator.tech/).
- Verified that the table formatting is correct and matches the existing style.

Fixes #17

---
*PR created automatically by Jules for task [8617857817299039617](https://jules.google.com/task/8617857817299039617) started by @chatelao*