### PR TITLE
Add Arduino and PlatformIO setup for XIAO RP2040 and STM32G431

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -13,6 +13,8 @@
 | Infrastruktur | Vast.ai SDK | Management von GPU-Instanzen | `pip install vastai` | [Link](https://github.com/Vast-ai/vast-python) |
 | KI-Inferenz | Ollama | Lokaler Betrieb von LLMs | `curl -fsSL https://ollama.com/install.sh \| sh` | [Link](https://ollama.com/) |
 | KI-Inferenz | vLLM | LLM Inferenz-Engine | `pip install vllm` | [Link](https://github.com/vllm-project/vllm) |
+| Programmierung | Arduino CLI | CLI für Arduino-Projekte (XIAO RP2040, STM32G431) | `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh \| BINDIR=$HOME/.local/bin sh` | [Link](https://arduino.github.io/arduino-cli/) |
 | Programmierung | Blockly | Visuelle Programmierung | `npm install blockly` | [Link](https://developers.google.com/blockly) |
 | Programmierung | Pawn Compiler | Skriptsprache für Embedded Systems | - | [Link](https://github.com/compuphase/pawn) |
+| Programmierung | PlatformIO Core | Build-System für Embedded-Entwicklung (XIAO RP2040, STM32G431) | `pip install platformio` | [Link](https://platformio.org/) |
 | Testing | Playwright | E2E Testing für Webanwendungen | `npm install playwright` | [Link](https://playwright.dev/) |


### PR DESCRIPTION
Added Arduino CLI and PlatformIO Core to TOOLS.md with installation commands and purposes. Both tools are described as supporting Seeed Studio XIAO RP2040 and STM32G431. Maintained alphabetical order and German language conventions.

Fixes #16

---
*PR created automatically by Jules for task [920502498433451238](https://jules.google.com/task/920502498433451238) started by @chatelao*