### PR TITLE
Add FreeCAD and OpenSCAD to TOOLS.md

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2,8 +2,10 @@
 
 | Gruppe | Name | Zweck | Installationsbefehle | Referenzhandbuch |
 | :--- | :--- | :--- | :--- | :--- |
+| CAD/3D | FreeCAD | Parametrischer 3D-Modellierer | `sudo add-apt-repository ppa:freecad-maintainers/freecad-stable; sudo apt update; sudo apt install freecad` | [Link](https://www.freecad.org/) |
 | CAD/3D | MCP-FreeCAD | Model Context Protocol für FreeCAD | - | [Link](https://github.com/jango-blockchained/mcp-freecad) |
 | CAD/3D | MeshLab | Bearbeitung von 3D-Meshes | `sudo apt install meshlab` | [Link](https://www.meshlab.net/) |
+| CAD/3D | OpenSCAD | Der Programmierer unter den 3D-CAD-Modellierern | `sudo apt install openscad` | [Link](https://openscad.org/) |
 | Dokumentation | Apache FOP | Print Formatter für XSL-FO | `sudo apt install fop` | [Link](https://xmlgraphics.apache.org/fop/) |
 | Dokumentation | PlantUML | UML-Diagramm-Renderer | `sudo apt install plantuml` | [Link](https://plantuml.com/) |
 | Dokumentation | WaveDrom | Zeitdiagramm-Renderer | `npm install wavedrom` | [Link](https://wavedrom.com/) |


### PR DESCRIPTION
The user wanted to add FreeCAD and OpenSCAD to the tool documentation.
I researched the installation methods for Ubuntu 24.04 (Noble):
- FreeCAD requires `ppa:freecad-maintainers/freecad-stable`.
- OpenSCAD is available in the `universe` repository.
I then updated `TOOLS.md` to include both tools in the `CAD/3D` group, maintaining alphabetical order.
Verified the changes and received a positive code review.

Fixes #18

---
*PR created automatically by Jules for task [13415738622144095440](https://jules.google.com/task/13415738622144095440) started by @chatelao*