### PR TITLE
Add VISUALIZATION.md mapping results to tools

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,3 +21,8 @@ Diese Dokumentation dient als zentrale Anlaufstelle für KI-Agenten, um Werkzeug
 - **Format:** Die Datensammlungen werden ebenfalls in Tabellenform dokumentiert.
 - **Inhalte:** Jedes Sammlung wird mit Gruppe, Name, Zweck, Zugriffarten zum Beschaffung und/oder Abfrage beschrieben, Referenzhandbuch
 - **Abfragbarkeit:** Vor der Aufnahme in die Liste wird die Software auf Installierbarkeit geprüft.
+
+#### Visualisierungen
+- **Speicherort:** Führe die Mappings von Ergebnissen zu Werkzeugen in [VISUALIZATION.md](VISUALIZATION.md)
+- **Format:** Die Zuordnungen werden in Tabellenform dokumentiert.
+- **Inhalte:** Jeder Eintrag enthält den Visualisierungstyp, das Werkzeug und die Gruppe.

--- a/VISUALIZATION.md
+++ b/VISUALIZATION.md
@@ -1,0 +1,22 @@
+# Visualisierungen
+
+Diese Dokumentation ordnet gewünschte Visualisierungsergebnisse den entsprechenden Werkzeugen zu.
+
+| Visualisierungstyp | Werkzeug | Gruppe |
+| :--- | :--- | :--- |
+| 2D-Animationen | Krita | Animation |
+| 2D-Animationen | Pencil2D | Animation |
+| 2D-Animationen | Synfig Studio | Animation |
+| 3D-CAD-Modelle | FreeCAD | CAD/3D |
+| 3D-CAD-Modelle | OpenSCAD | CAD/3D |
+| 3D-Modelle (allgemein) | Blender | Animation |
+| 3D-Modelle (LDraw) | LDView | CAD/3D |
+| 3D-Modelle (Meshes) | MeshLab | CAD/3D |
+| Elektrische Schaltungen | CircuiTikZ | Hardware/EDA |
+| Elektronik-Design (PCB) | KiCad 10.0 | EDA |
+| Mathematische Animationen | Manim | Animation |
+| Molekülvisualisierung | Jmol | Bioinformatik |
+| Molekülvisualisierung | PyMOL | Bioinformatik |
+| UML-Diagramme | PlantUML | Dokumentation |
+| Visuelle Programmierung | Blockly | Programmierung |
+| Zeitdiagramme | WaveDrom | Dokumentation |


### PR DESCRIPTION
This change introduces a new documentation file `VISUALIZATION.md` that provides a clear mapping between desired visualization results (e.g., UML diagrams, timing diagrams, 3D models) and the tools available in the repository (e.g., PlantUML, WaveDrom, FreeCAD). 

Additionally, the central strategy document `GEMINI.md` has been updated to include this new documentation component in the "Documentation" section, ensuring it is part of the overall AI agent tool management strategy. 

All tables follow the established German language convention and are sorted alphabetically for better readability.

Fixes #36

---
*PR created automatically by Jules for task [18305920183261253725](https://jules.google.com/task/18305920183261253725) started by @chatelao*