### PR TITLE
Synchronize visualization tools with tools documentation

### DIFF
--- a/DATASOURCES.md
+++ b/DATASOURCES.md
@@ -7,7 +7,6 @@
 | Finanzen | eCH-0196 | Schweizer Steuerauszug | XML Import | - |
 | Finanzen | ISO 20022 camt.053 | Bankkontoauszüge | XML Import | - |
 | Geodaten | Overpass Turbo | Webbasiertes Datensammelwerkzeug für OpenStreetMap | Overpass API / Web-GUI | [Link](https://wiki.openstreetmap.org/wiki/DE:Overpass_turbo) |
-| Hardware/EDA | CircuiTikZ | TeX/LaTeX-Paket zum Zeichnen von elektrischen Schaltungen | `sudo apt-get install texlive-pictures` | [Handbuch](https://mirror.init7.net/ctan/graphics/pgf/contrib/circuitikz/doc/circuitikzmanual.pdf) |
 | Hardware/EDA | IHP Open PDK | Open Source PDK (130nm) | git clone | [Link](https://github.com/IHP-GmbH/IHP-Open-PDK) |
 | Hardware/EDA | LDraw Parts Library | Standardbibliothek von LEGO-Teil-Definitionen | Download via ldview.deb/ldraw.deb | [Link](https://www.ldraw.org/) |
 | KI-Modelle | Hugging Face | Modell-Repository | `huggingface-cli download` | [Link](https://huggingface.co/) |

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -23,6 +23,7 @@
 | Dokumentation | img2pdf | Verlustfreie Konvertierung von Bildern in PDF | `sudo apt install img2pdf` | [Link](https://github.com/josch/img2pdf) |
 | Dokumentation | PlantUML | UML-Diagramm-Renderer | `sudo apt install plantuml` | [Link](https://plantuml.com/) |
 | Dokumentation | WaveDrom | Zeitdiagramm-Renderer | `npm install wavedrom` | [Link](https://wavedrom.com/) |
+| EDA | CircuiTikZ | TeX/LaTeX-Paket zum Zeichnen von elektrischen Schaltungen | `sudo apt install texlive-pictures` | [Link](https://mirror.init7.net/ctan/graphics/pgf/contrib/circuitikz/doc/circuitikzmanual.pdf) |
 | EDA | KiBot | Automatisierung für KiCAD | `pip install kibot` | [Link](https://github.com/INTI-CMNB/KiBot) |
 | EDA | KiCad 10.0 | Elektronik-Design-Automatisierung | `sudo add-apt-repository ppa:kicad/kicad-10.0-releases; sudo apt update; sudo apt install --install-recommends kicad` | [Link](https://www.kicad.org/) |
 | EDA | SKiDL | Schaltungsentwurf in Python | `pip install skidl` | [Link](https://devbisme.github.io/skidl/) |

--- a/VISUALIZATION.md
+++ b/VISUALIZATION.md
@@ -4,19 +4,19 @@ Diese Dokumentation ordnet gewünschte Visualisierungsergebnisse den entsprechen
 
 | Visualisierungstyp | Werkzeug | Gruppe |
 | :--- | :--- | :--- |
+| 3D-Modelle (allgemein) | Blender | Animation |
 | 2D-Animationen | Krita | Animation |
+| Mathematische Animationen | Manim | Animation |
 | 2D-Animationen | Pencil2D | Animation |
 | 2D-Animationen | Synfig Studio | Animation |
-| 3D-CAD-Modelle | FreeCAD | CAD/3D |
-| 3D-CAD-Modelle | OpenSCAD | CAD/3D |
-| 3D-Modelle (allgemein) | Blender | Animation |
-| 3D-Modelle (LDraw) | LDView | CAD/3D |
-| 3D-Modelle (Meshes) | MeshLab | CAD/3D |
-| Elektrische Schaltungen | CircuiTikZ | Hardware/EDA |
-| Elektronik-Design (PCB) | KiCad 10.0 | EDA |
-| Mathematische Animationen | Manim | Animation |
 | Molekülvisualisierung | Jmol | Bioinformatik |
 | Molekülvisualisierung | PyMOL | Bioinformatik |
+| 3D-CAD-Modelle | FreeCAD | CAD/3D |
+| 3D-Modelle (LDraw) | LDView | CAD/3D |
+| 3D-Modelle (Meshes) | MeshLab | CAD/3D |
+| 3D-CAD-Modelle | OpenSCAD | CAD/3D |
 | UML-Diagramme | PlantUML | Dokumentation |
-| Visuelle Programmierung | Blockly | Programmierung |
 | Zeitdiagramme | WaveDrom | Dokumentation |
+| Elektrische Schaltungen | CircuiTikZ | EDA |
+| Elektronik-Design (PCB) | KiCad 10.0 | EDA |
+| Visuelle Programmierung | Blockly | Programmierung |


### PR DESCRIPTION
The task was to verify if all elements from `VISUALIZATION.md` are present in `TOOLS.md`. 
I found that `CircuiTikZ` was listed in `DATASOURCES.md` instead of `TOOLS.md`. 
I moved `CircuiTikZ` to `TOOLS.md` under the `EDA` group and updated its group in `VISUALIZATION.md` for consistency. 
Additionally, I sorted the `VISUALIZATION.md` table alphabetically by Group, Werkzeug, and Visualisierungstyp to match the project's documentation standards and make future verification easier.

Fixes #41

---
*PR created automatically by Jules for task [435329427604946075](https://jules.google.com/task/435329427604946075) started by @chatelao*