### PR TITLE
Add tools for SOAP, XSD, and XML interfaces

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -51,6 +51,10 @@
 | Programmierung | Pawn Compiler | Skriptsprache für Embedded Systems | - | [Link](https://github.com/compuphase/pawn) | [Link](factsheets/programmierung/pawn-compiler/README.md) |
 | Programmierung | Pillow | Python Imaging Library | `pip install Pillow` | [Link](https://python-pillow.org/) | [Link](factsheets/programmierung/pillow/README.md) |
 | Programmierung | PlatformIO Core | Build-System für Embedded-Entwicklung (XIAO RP2040, STM32G431) | `pip install platformio` | [Link](https://platformio.org/) | [Link](factsheets/programmierung/platformio-core/README.md) |
+| Schnittstellen | xmllint | GNOME XML-Werkzeug zur Validierung und Formatierung | `sudo apt install libxml2-utils` | [Link](http://xmlsoft.org/xmllint.html) | [Link](factsheets/schnittstellen/xmllint/README.md) |
+| Schnittstellen | XMLStarlet | Toolkit zur XML-Verarbeitung von der Kommandozeile | `sudo apt install xmlstarlet` | [Link](https://xmlstar.sourceforge.net/) | [Link](factsheets/schnittstellen/xmlstarlet/README.md) |
+| Schnittstellen | xsltproc | Kommandozeilen-Prozessor für XSLT 1.0 | `sudo apt install xsltproc` | [Link](http://xmlsoft.org/XSLT/xsltproc2.html) | [Link](factsheets/schnittstellen/xsltproc/README.md) |
+| Schnittstellen | Zeep | Moderne SOAP-Client-Bibliothek für Python | `sudo apt install python3-zeep` | [Link](https://docs.python-zeep.org/) | [Link](factsheets/schnittstellen/zeep/README.md) |
 | Testing | Hurl | CLI-Tool zum Ausführen von HTTP-Anfragen (REST, SOAP, GraphQL) mit einfachem Textformat | `sudo add-apt-repository ppa:lepapareil/hurl; sudo apt update; sudo apt install hurl` | [Link](https://hurl.dev/) | [Link](factsheets/testing/hurl/README.md) |
 | Testing | Playwright | E2E Testing für Webanwendungen | `npm install playwright` | [Link](https://playwright.dev/) | [Link](factsheets/testing/playwright/README.md) |
 | Testing | Schemathesis | Eigenschaftsbasiertes Testen für OpenAPI- und GraphQL-Spezifikationen | `pip install schemathesis` | [Link](https://schemathesis.io/) | [Link](factsheets/testing/schemathesis/README.md) |

--- a/factsheets/schnittstellen/xmllint/README.md
+++ b/factsheets/schnittstellen/xmllint/README.md
@@ -1,0 +1,35 @@
+# Factsheet: xmllint
+
+## Gruppe: Schnittstellen
+
+## Zweck: xmllint ist ein Werkzeug aus dem libxml2-Paket zur Validierung, Formatierung und Analyse von XML-Dateien.
+
+## Installation (Ubuntu 24.04)
+
+```bash
+sudo apt install libxml2-utils
+```
+
+## Beispieldaten
+
+Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
+
+- `valid.xml`: Eine valide XML-Datei.
+- `invalid.xml`: Eine XML-Datei mit Syntaxfehlern.
+- `schema.xsd`: Ein XML-Schema zur Validierung.
+- `data_to_validate.xml`: XML-Daten, die gegen das Schema geprüft werden können.
+- `formatted.xml`: Beispiel für eine formatierte XML-Ausgabe.
+
+## Validierung
+
+XML-Datei auf Wohlgeformtheit prüfen:
+
+```bash
+xmllint --noout factsheets/schnittstellen/xmllint/examples/valid.xml
+```
+
+XML gegen XSD-Schema validieren:
+
+```bash
+xmllint --schema factsheets/schnittstellen/xmllint/examples/schema.xsd factsheets/schnittstellen/xmllint/examples/data_to_validate.xml --noout
+```

--- a/factsheets/schnittstellen/xmllint/examples/data_to_validate.xml
+++ b/factsheets/schnittstellen/xmllint/examples/data_to_validate.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<note>
+  <to>Tove</to>
+  <from>Jani</from>
+  <heading>Reminder</heading>
+  <body>Don't forget me this weekend!</body>
+</note>

--- a/factsheets/schnittstellen/xmllint/examples/formatted.xml
+++ b/factsheets/schnittstellen/xmllint/examples/formatted.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root><item id="1">Text</item><item id="2">Mehr Text</item></root>

--- a/factsheets/schnittstellen/xmllint/examples/invalid.xml
+++ b/factsheets/schnittstellen/xmllint/examples/invalid.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <element>Nicht geschlossen
+</root>

--- a/factsheets/schnittstellen/xmllint/examples/schema.xsd
+++ b/factsheets/schnittstellen/xmllint/examples/schema.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="note">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="to" type="xs:string"/>
+        <xs:element name="from" type="xs:string"/>
+        <xs:element name="heading" type="xs:string"/>
+        <xs:element name="body" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/factsheets/schnittstellen/xmllint/examples/valid.xml
+++ b/factsheets/schnittstellen/xmllint/examples/valid.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <element>Inhalt</element>
+</root>

--- a/factsheets/schnittstellen/xmlstarlet/README.md
+++ b/factsheets/schnittstellen/xmlstarlet/README.md
@@ -1,0 +1,35 @@
+# Factsheet: XMLStarlet
+
+## Gruppe: Schnittstellen
+
+## Zweck: XMLStarlet ist ein Toolkit zur XML-Verarbeitung von der Kommandozeile (Validierung, Abfrage, Transformation, Bearbeitung).
+
+## Installation (Ubuntu 24.04)
+
+```bash
+sudo apt install xmlstarlet
+```
+
+## Beispieldaten
+
+Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
+
+- `catalog.xml`: Eine einfache XML-Datei mit Buchdaten.
+- `books.xml`: Eine weitere XML-Datei für Abfragen.
+- `inventory.xml`: Inventardaten zur Bearbeitung.
+- `config.xml`: Konfigurationsbeispiel.
+- `data.xml`: Allgemeine XML-Daten.
+
+## Validierung
+
+XML-Datei formatieren (Pretty Print):
+
+```bash
+xmlstarlet fo factsheets/schnittstellen/xmlstarlet/examples/catalog.xml
+```
+
+Elemente mit XPath abfragen:
+
+```bash
+xmlstarlet sel -t -v "/catalog/book/title" factsheets/schnittstellen/xmlstarlet/examples/catalog.xml
+```

--- a/factsheets/schnittstellen/xmlstarlet/examples/books.xml
+++ b/factsheets/schnittstellen/xmlstarlet/examples/books.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<books>
+  <book category="cooking">
+    <title lang="en">Everyday Italian</title>
+    <author>Giada De Laurentiis</author>
+    <year>2005</year>
+    <price>30.00</price>
+  </book>
+  <book category="children">
+    <title lang="en">Harry Potter</title>
+    <author>J K. Rowling</author>
+    <year>2005</year>
+    <price>29.99</price>
+  </book>
+</books>

--- a/factsheets/schnittstellen/xmlstarlet/examples/catalog.xml
+++ b/factsheets/schnittstellen/xmlstarlet/examples/catalog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications with XML.</description>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-12-16</publish_date>
+      <description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
+   </book>
+</catalog>

--- a/factsheets/schnittstellen/xmlstarlet/examples/config.xml
+++ b/factsheets/schnittstellen/xmlstarlet/examples/config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config>
+  <settings>
+    <theme>dark</theme>
+    <language>de</language>
+  </settings>
+</config>

--- a/factsheets/schnittstellen/xmlstarlet/examples/data.xml
+++ b/factsheets/schnittstellen/xmlstarlet/examples/data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<data>
+  <record>
+    <id>1001</id>
+    <value>Alpha</value>
+  </record>
+  <record>
+    <id>1002</id>
+    <value>Beta</value>
+  </record>
+</data>

--- a/factsheets/schnittstellen/xmlstarlet/examples/inventory.xml
+++ b/factsheets/schnittstellen/xmlstarlet/examples/inventory.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<inventory>
+  <item id="1">
+    <name>Laptop</name>
+    <stock>10</stock>
+  </item>
+  <item id="2">
+    <name>Monitor</name>
+    <stock>25</stock>
+  </item>
+</inventory>

--- a/factsheets/schnittstellen/xsltproc/README.md
+++ b/factsheets/schnittstellen/xsltproc/README.md
@@ -1,0 +1,35 @@
+# Factsheet: xsltproc
+
+## Gruppe: Schnittstellen
+
+## Zweck: xsltproc ist ein Kommandozeilen-Werkzeug zur Anwendung von XSLT-Stylesheets auf XML-Dokumente.
+
+## Installation (Ubuntu 24.04)
+
+```bash
+sudo apt install xsltproc
+```
+
+## Beispieldaten
+
+Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
+
+- `source.xml`: Die XML-Quelldatei.
+- `transform.xsl`: Das XSLT-Stylesheet für die Transformation.
+- `books.xml`: Eine Liste von Büchern als Datenquelle.
+- `to_html.xsl`: XSLT zur Umwandlung von Buchdaten in HTML.
+- `params.xsl`: Beispiel für XSLT mit Parametern.
+
+## Validierung
+
+XML-Transformation durchführen:
+
+```bash
+xsltproc factsheets/schnittstellen/xsltproc/examples/transform.xsl factsheets/schnittstellen/xsltproc/examples/source.xml
+```
+
+XML in HTML umwandeln:
+
+```bash
+xsltproc -o factsheets/schnittstellen/xsltproc/examples/books.html factsheets/schnittstellen/xsltproc/examples/to_html.xsl factsheets/schnittstellen/xsltproc/examples/books.xml
+```

--- a/factsheets/schnittstellen/xsltproc/examples/books.html
+++ b/factsheets/schnittstellen/xsltproc/examples/books.html
@@ -1,0 +1,17 @@
+<html><body>
+<h2>Library</h2>
+<table border="1">
+<tr bgcolor="#9acd32">
+<th>Title</th>
+<th>Author</th>
+</tr>
+<tr>
+<td>XSLT Basics</td>
+<td>John Doe</td>
+</tr>
+<tr>
+<td>XML Power</td>
+<td>Jane Smith</td>
+</tr>
+</table>
+</body></html>

--- a/factsheets/schnittstellen/xsltproc/examples/books.xml
+++ b/factsheets/schnittstellen/xsltproc/examples/books.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<library>
+  <book>
+    <title>XSLT Basics</title>
+    <author>John Doe</author>
+  </book>
+  <book>
+    <title>XML Power</title>
+    <author>Jane Smith</author>
+  </book>
+</library>

--- a/factsheets/schnittstellen/xsltproc/examples/params.xsl
+++ b/factsheets/schnittstellen/xsltproc/examples/params.xsl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:param name="myParam" select="'Default Value'"/>
+  <xsl:template match="/">
+    <result>
+      <paramValue><xsl:value-of select="$myParam"/></paramValue>
+    </result>
+  </xsl:template>
+</xsl:stylesheet>

--- a/factsheets/schnittstellen/xsltproc/examples/source.xml
+++ b/factsheets/schnittstellen/xsltproc/examples/source.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<message>Hallo Welt</message>

--- a/factsheets/schnittstellen/xsltproc/examples/to_html.xsl
+++ b/factsheets/schnittstellen/xsltproc/examples/to_html.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <html>
+      <body>
+        <h2>Library</h2>
+        <table border="1">
+          <tr bgcolor="#9acd32">
+            <th>Title</th>
+            <th>Author</th>
+          </tr>
+          <xsl:for-each select="library/book">
+            <tr>
+              <td><xsl:value-of select="title"/></td>
+              <td><xsl:value-of select="author"/></td>
+            </tr>
+          </xsl:for-each>
+        </table>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/factsheets/schnittstellen/xsltproc/examples/transform.xsl
+++ b/factsheets/schnittstellen/xsltproc/examples/transform.xsl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <output>
+      <text><xsl:value-of select="message"/></text>
+    </output>
+  </xsl:template>
+</xsl:stylesheet>

--- a/factsheets/schnittstellen/zeep/README.md
+++ b/factsheets/schnittstellen/zeep/README.md
@@ -1,0 +1,35 @@
+# Factsheet: Zeep
+
+## Gruppe: Schnittstellen
+
+## Zweck: Zeep ist eine moderne SOAP-Client-Bibliothek für Python, die WSDL-Dateien parst und eine komfortable API bietet.
+
+## Installation (Ubuntu 24.04)
+
+```bash
+sudo apt install python3-zeep
+```
+
+## Beispieldaten
+
+Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
+
+- `service.wsdl`: Eine Beispiel-WSDL-Datei.
+- `client.py`: Ein Python-Skript, das Zeep zur Kommunikation nutzt.
+- `request.xml`: Eine Beispiel-SOAP-Anfrage.
+- `response.xml`: Eine Beispiel-SOAP-Antwort.
+- `schema.xsd`: Begleitendes XML-Schema für den Service.
+
+## Validierung
+
+WSDL-Datei inspizieren:
+
+```bash
+python3 -m zeep factsheets/schnittstellen/zeep/examples/service.wsdl
+```
+
+Beispiel-Client ausführen (erfordert evtl. Mock-Server oder Netzwerk):
+
+```bash
+python3 factsheets/schnittstellen/zeep/examples/client.py
+```

--- a/factsheets/schnittstellen/zeep/examples/client.py
+++ b/factsheets/schnittstellen/zeep/examples/client.py
@@ -1,0 +1,10 @@
+import zeep
+import os
+
+wsdl_path = os.path.join(os.path.dirname(__file__), 'service.wsdl')
+client = zeep.Client(wsdl=wsdl_path)
+
+# In einer echten Umgebung würde man hier einen Call absetzen
+# client.service.GetLastTradePrice(tickerSymbol='AAPL')
+
+print("Zeep client initialized successfully with WSDL.")

--- a/factsheets/schnittstellen/zeep/examples/request.xml
+++ b/factsheets/schnittstellen/zeep/examples/request.xml
@@ -1,0 +1,8 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:stoc="http://example.com/stockquote.xsd">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <stoc:TradePriceRequest>
+         <stoc:tickerSymbol>AAPL</stoc:tickerSymbol>
+      </stoc:TradePriceRequest>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/factsheets/schnittstellen/zeep/examples/response.xml
+++ b/factsheets/schnittstellen/zeep/examples/response.xml
@@ -1,0 +1,8 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:stoc="http://example.com/stockquote.xsd">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <stoc:TradePrice>
+         <stoc:price>150.25</stoc:price>
+      </stoc:TradePrice>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/factsheets/schnittstellen/zeep/examples/schema.xsd
+++ b/factsheets/schnittstellen/zeep/examples/schema.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://example.com/stockquote.xsd"
+        xmlns:tns="http://example.com/stockquote.xsd"
+        xmlns="http://www.w3.org/2001/XMLSchema">
+  <element name="TradePriceRequest">
+    <complexType>
+      <all>
+        <element name="tickerSymbol" type="string"/>
+      </all>
+    </complexType>
+  </element>
+  <element name="TradePrice">
+    <complexType>
+      <all>
+        <element name="price" type="float"/>
+      </all>
+    </complexType>
+  </element>
+</schema>

--- a/factsheets/schnittstellen/zeep/examples/service.wsdl
+++ b/factsheets/schnittstellen/zeep/examples/service.wsdl
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions name="StockQuote"
+             targetNamespace="http://example.com/stockquote.wsdl"
+             xmlns:tns="http://example.com/stockquote.wsdl"
+             xmlns:xsd1="http://example.com/stockquote.xsd"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns="http://schemas.xmlsoap.org/wsdl/">
+
+  <types>
+    <schema targetNamespace="http://example.com/stockquote.xsd"
+            xmlns="http://www.w3.org/2001/XMLSchema">
+      <element name="TradePriceRequest">
+        <complexType>
+          <all>
+            <element name="tickerSymbol" type="string"/>
+          </all>
+        </complexType>
+      </element>
+      <element name="TradePrice">
+        <complexType>
+          <all>
+            <element name="price" type="float"/>
+          </all>
+        </complexType>
+      </element>
+    </schema>
+  </types>
+
+  <message name="GetLastTradePriceInput">
+    <part name="body" element="xsd1:TradePriceRequest"/>
+  </message>
+
+  <message name="GetLastTradePriceOutput">
+    <part name="body" element="xsd1:TradePrice"/>
+  </message>
+
+  <portType name="StockQuotePortType">
+    <operation name="GetLastTradePrice">
+      <input message="tns:GetLastTradePriceInput"/>
+      <output message="tns:GetLastTradePriceOutput"/>
+    </operation>
+  </portType>
+
+  <binding name="StockQuoteSoapBinding" type="tns:StockQuotePortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="GetLastTradePrice">
+      <soap:operation soapAction="http://example.com/GetLastTradePrice"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+
+  <service name="StockQuoteService">
+    <port name="StockQuotePort" binding="tns:StockQuoteSoapBinding">
+      <soap:address location="http://example.com/stockquote"/>
+    </port>
+  </service>
+
+</definitions>


### PR DESCRIPTION
This PR introduces a suite of tools for handling XML-based interfaces, including SOAP and XSD validation.

### Added Tools:
- **XMLStarlet**: A command-line toolkit for XML transformation, query, and editing.
- **xmllint** (from `libxml2-utils`): A powerful tool for XML validation (including XSD) and formatting.
- **xsltproc**: A command-line XSLT processor for applying stylesheets to XML documents.
- **Zeep**: A modern SOAP client library for Python.

### Documentation Changes:
- New group `Schnittstellen` in `TOOLS.md`.
- Four new factsheets under `factsheets/schnittstellen/` with installation instructions and validation steps.
- 5 examples for each tool demonstrating core capabilities (e.g., XSD validation, XSLT to HTML transformation, SOAP WSDL inspection).

All tools have been verified to work on the target Ubuntu 24.04 environment.

Fixes #48

---
*PR created automatically by Jules for task [11748513166261343497](https://jules.google.com/task/11748513166261343497) started by @chatelao*