### PR TITLE
Add tools to handle swagger / openapi api definitions

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -25,6 +25,7 @@
 | Dokumentation | Apache FOP | Print Formatter für XSL-FO | `sudo apt install fop` | [Link](https://xmlgraphics.apache.org/fop/) | [Link](factsheets/dokumentation/apache-fop/README.md) |
 | Dokumentation | img2pdf | Verlustfreie Konvertierung von Bildern in PDF | `sudo apt install img2pdf` | [Link](https://github.com/josch/img2pdf) | [Link](factsheets/dokumentation/img2pdf/README.md) |
 | Dokumentation | PlantUML | UML-Diagramm-Renderer | `sudo apt install plantuml` | [Link](https://plantuml.com/) | [Link](factsheets/dokumentation/plantuml/README.md) |
+| Dokumentation | Redocly CLI | CLI für OpenAPI-Dokumentation, Linting und Bündelung | `npm install @redocly/cli` | [Link](https://redocly.com/docs/cli/) | [Link](factsheets/dokumentation/redocly-cli/README.md) |
 | Dokumentation | WaveDrom | Zeitdiagramm-Renderer | `npm install wavedrom` | [Link](https://wavedrom.com/) | [Link](factsheets/dokumentation/wavedrom/README.md) |
 | EDA | CircuiTikZ | TeX/LaTeX-Paket zum Zeichnen von elektrischen Schaltungen | `sudo apt install texlive-pictures` | [Link](https://mirror.init7.net/ctan/graphics/pgf/contrib/circuitikz/doc/circuitikzmanual.pdf) | [Link](factsheets/eda/circuitikz/README.md) |
 | EDA | KiBot | Automatisierung für KiCAD | `pip install kibot` | [Link](https://github.com/INTI-CMNB/KiBot) | [Link](factsheets/eda/kibot/README.md) |
@@ -53,5 +54,7 @@
 | Programmierung | PlatformIO Core | Build-System für Embedded-Entwicklung (XIAO RP2040, STM32G431) | `pip install platformio` | [Link](https://platformio.org/) | [Link](factsheets/programmierung/platformio-core/README.md) |
 | Testing | Hurl | CLI-Tool zum Ausführen von HTTP-Anfragen (REST, SOAP, GraphQL) mit einfachem Textformat | `sudo add-apt-repository ppa:lepapareil/hurl; sudo apt update; sudo apt install hurl` | [Link](https://hurl.dev/) | [Link](factsheets/testing/hurl/README.md) |
 | Testing | Playwright | E2E Testing für Webanwendungen | `npm install playwright` | [Link](https://playwright.dev/) | [Link](factsheets/testing/playwright/README.md) |
+| Testing | Prism | Mock-Server für OpenAPI-Spezifikationen | `npm install @stoplight/prism-cli` | [Link](https://stoplight.io/open-source/prism) | [Link](factsheets/testing/prism/README.md) |
 | Testing | Schemathesis | Eigenschaftsbasiertes Testen für OpenAPI- und GraphQL-Spezifikationen | `pip install schemathesis` | [Link](https://schemathesis.io/) | [Link](factsheets/testing/schemathesis/README.md) |
+| Testing | Spectral | Flexibler Linter für JSON/YAML, spezialisiert auf OpenAPI | `npm install @stoplight/spectral-cli` | [Link](https://stoplight.io/open-source/spectral) | [Link](factsheets/testing/spectral/README.md) |
 | Testing | Step CI | Deklaratives Open-Source-Framework für API-Tests (REST, OpenAPI, GraphQL) | `npm install -g stepci` | [Link](https://stepci.com/) | [Link](factsheets/testing/step-ci/README.md) |

--- a/VISUALIZATION.md
+++ b/VISUALIZATION.md
@@ -19,6 +19,7 @@ Diese Dokumentation ordnet gewünschte Visualisierungsergebnisse den entsprechen
 | 3D-Modelle (LDraw) | LDView | CAD/3D |
 | 3D-Modelle (Meshes) | MeshLab | CAD/3D |
 | 3D-CAD-Modelle | OpenSCAD | CAD/3D |
+| API-Dokumentation | Redocly CLI | Dokumentation |
 | UML-Diagramme | PlantUML | Dokumentation |
 | Zeitdiagramme | WaveDrom | Dokumentation |
 | Elektrische Schaltungen | CircuiTikZ | EDA |

--- a/factsheets/dokumentation/redocly-cli/README.md
+++ b/factsheets/dokumentation/redocly-cli/README.md
@@ -1,0 +1,33 @@
+# Factsheet: Redocly CLI
+
+## Gruppe: Dokumentation
+
+## Zweck: Redocly CLI ist ein CLI für OpenAPI-Dokumentation, Linting und Bündelung
+
+Redocly CLI bietet Werkzeuge zum Validieren (Linting), Bündeln (Bundling) und
+Rendern von OpenAPI-Spezifikationen. Es kann statische HTML-Dokumentationen
+generieren und APIs in der Vorschau anzeigen.
+
+## Installation (Ubuntu 24.04)
+
+```bash
+npm install @redocly/cli
+```
+
+## Beispieldaten
+
+Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
+
+- `api.yaml`: Eine OpenAPI-Spezifikation für die Dokumentationserstellung.
+- `redocly.yaml`: Konfigurationsdatei für Redocly.
+- `bundle.sh`: Skript zum Bündeln mehrteiliger API-Definitionen.
+- `build-docs.sh`: Skript zum Generieren statischer HTML-Dokumentation.
+- `preview.sh`: Skript zur Vorschau der API-Dokumentation.
+
+## Validierung
+
+OpenAPI-Schema validieren:
+
+```bash
+npx @redocly/cli lint factsheets/dokumentation/redocly-cli/examples/api.yaml
+```

--- a/factsheets/dokumentation/redocly-cli/examples/api.yaml
+++ b/factsheets/dokumentation/redocly-cli/examples/api.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.0
+info:
+  title: Redocly API
+  version: 1.0.0
+paths:
+  /docs:
+    get:
+      responses:
+        '200':
+          description: Returns documentation info

--- a/factsheets/dokumentation/redocly-cli/examples/build-docs.sh
+++ b/factsheets/dokumentation/redocly-cli/examples/build-docs.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npx @redocly/cli build-docs api.yaml -o index.html

--- a/factsheets/dokumentation/redocly-cli/examples/bundle.sh
+++ b/factsheets/dokumentation/redocly-cli/examples/bundle.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npx @redocly/cli bundle api.yaml -o bundled.yaml

--- a/factsheets/dokumentation/redocly-cli/examples/preview.sh
+++ b/factsheets/dokumentation/redocly-cli/examples/preview.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npx @redocly/cli preview-docs api.yaml

--- a/factsheets/dokumentation/redocly-cli/examples/redocly.yaml
+++ b/factsheets/dokumentation/redocly-cli/examples/redocly.yaml
@@ -1,0 +1,6 @@
+apis:
+  main:
+    root: ./api.yaml
+lint:
+  extends:
+    - recommended

--- a/factsheets/programmierung/openapi-generator/README.md
+++ b/factsheets/programmierung/openapi-generator/README.md
@@ -2,7 +2,9 @@
 
 ## Gruppe: Programmierung
 
-## Zweck: Openapi-generator ist ein Werkzeug für
+## Zweck: Openapi-generator ist ein Werkzeug für die automatische Codegenerierung
+
+Das Tool ermöglicht die Generierung von API-Clients, Server-Stubs, Dokumentationen und Konfigurationsdateien aus OpenAPI-Spezifikationen (v2, v3). Es unterstützt eine Vielzahl von Programmiersprachen und Frameworks.
 
 ## Installation (Ubuntu 24.04)
 
@@ -14,12 +16,22 @@ npm install @openapitools/openapi-generator-cli
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
 
-- `api.yaml`
-- `config.json`
-- `out.sh`
-- `test.json`
-- `doc.md`
+- `api.yaml`: Eine Beispiel-OpenAPI-Spezifikation.
+- `config.json`: Konfiguration für den Generator.
+- `out.sh`: Skript zur Ausführung der Codegenerierung.
+- `test.json`: Beispieldaten für Tests.
+- `doc.md`: Generierte Dokumentationsvorschau.
 
 ## Validierung
 
-Hilfe anzeigen.
+Hilfe anzeigen:
+
+```bash
+npx @openapitools/openapi-generator-cli help
+```
+
+Verfügbare Generatoren auflisten:
+
+```bash
+npx @openapitools/openapi-generator-cli list
+```

--- a/factsheets/testing/prism/README.md
+++ b/factsheets/testing/prism/README.md
@@ -1,0 +1,34 @@
+# Factsheet: Prism
+
+## Gruppe: Testing
+
+## Zweck: Prism ist ein Mock-Server für OpenAPI-Spezifikationen
+
+Prism ermöglicht es, basierend auf einer OpenAPI-Spezifikation (v2/v3),
+automatisch Mock-Server zu erstellen. Diese Server können API-Anfragen
+validieren und basierend auf dem Schema realistische Beispiel-Antworten
+generieren.
+
+## Installation (Ubuntu 24.04)
+
+```bash
+npm install @stoplight/prism-cli
+```
+
+## Beispieldaten
+
+Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
+
+- `api.yaml`: Eine OpenAPI-Spezifikation für die Generierung des Mock-Servers.
+- `prism-config.json`: Beispiel für eine Prism-Konfigurationsdatei.
+- `run-mock.sh`: Skript zum Starten des Mock-Servers.
+- `proxy.sh`: Skript zur Nutzung von Prism als Validierungsproxy.
+- `validate-request.sh`: Beispiel für eine Anfrage-Validierung.
+
+## Validierung
+
+Mock-Server starten:
+
+```bash
+npx prism mock factsheets/testing/prism/examples/api.yaml
+```

--- a/factsheets/testing/prism/examples/api.yaml
+++ b/factsheets/testing/prism/examples/api.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Mock API
+  version: 1.0.0
+paths:
+  /hello:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Hello World"

--- a/factsheets/testing/prism/examples/prism-config.json
+++ b/factsheets/testing/prism/examples/prism-config.json
@@ -1,0 +1,6 @@
+{
+  "mock": {
+    "dynamic": true,
+    "port": 4010
+  }
+}

--- a/factsheets/testing/prism/examples/proxy.sh
+++ b/factsheets/testing/prism/examples/proxy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Prism als Proxy zu einem existierenden Server nutzen, um Anfragen/Antworten zu validieren
+npx prism proxy api.yaml http://localhost:8080 --errors

--- a/factsheets/testing/prism/examples/run-mock.sh
+++ b/factsheets/testing/prism/examples/run-mock.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npx prism mock api.yaml -p 4010

--- a/factsheets/testing/prism/examples/validate-request.sh
+++ b/factsheets/testing/prism/examples/validate-request.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Beispiel-Request an den Mock-Server senden
+curl -X GET http://localhost:4010/hello

--- a/factsheets/testing/schemathesis/README.md
+++ b/factsheets/testing/schemathesis/README.md
@@ -2,7 +2,9 @@
 
 ## Gruppe: Testing
 
-## Zweck: Schemathesis ist ein Werkzeug für
+## Zweck: Schemathesis ist ein Werkzeug für das eigenschaftsbasierte Testen von APIs
+
+Schemathesis nutzt die OpenAPI-Spezifikation einer API, um automatisch Testfälle zu generieren, die die API auf Konformität und Robustheit prüfen. Es findet Abstürze, unerwartete Fehlercodes und Abweichungen von der Spezifikation.
 
 ## Installation (Ubuntu 24.04)
 
@@ -14,11 +16,11 @@ pip install schemathesis
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
 
-- `api.yaml`
-- `test.py`
-- `config.json`
-- `report.txt`
-- `hooks.py`
+- `api.yaml`: OpenAPI-Schema als Testgrundlage.
+- `test.py`: Python-Skript für fortgeschrittene Schemathesis-Tests.
+- `config.json`: Testkonfiguration.
+- `report.txt`: Beispiel für einen Testbericht.
+- `hooks.py`: Benutzerdefinierte Hooks für den Testprozess.
 
 ## Validierung
 

--- a/factsheets/testing/spectral/README.md
+++ b/factsheets/testing/spectral/README.md
@@ -1,0 +1,33 @@
+# Factsheet: Spectral
+
+## Gruppe: Testing
+
+## Zweck: Spectral ist ein flexibler Linter für JSON/YAML, spezialisiert auf OpenAPI
+
+Spectral ermöglicht das Linting von API-Beschreibungen (OpenAPI v2/v3, AsyncAPI),
+um die Einhaltung von Best Practices und Design-Richtlinien sicherzustellen. Es
+ist hochgradig erweiterbar durch eigene Regelsätze.
+
+## Installation (Ubuntu 24.04)
+
+```bash
+npm install @stoplight/spectral-cli
+```
+
+## Beispieldaten
+
+Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
+
+- `api.yaml`: Eine einfache, valide OpenAPI-Spezifikation.
+- `invalid.yaml`: Eine OpenAPI-Spezifikation mit absichtlichen Design-Fehlern.
+- `.spectral.yaml`: Standard-Konfigurationsdatei für Spectral.
+- `custom-ruleset.yaml`: Ein Beispiel für benutzerdefinierte Regeln.
+- `lint.sh`: Shell-Skript zur Ausführung des Linting-Prozesses.
+
+## Validierung
+
+OpenAPI-Schema linten:
+
+```bash
+npx spectral lint factsheets/testing/spectral/examples/api.yaml --ruleset factsheets/testing/spectral/examples/.spectral.yaml
+```

--- a/factsheets/testing/spectral/examples/.spectral.yaml
+++ b/factsheets/testing/spectral/examples/.spectral.yaml
@@ -1,0 +1,2 @@
+extends: spectral:oas
+rules: {}

--- a/factsheets/testing/spectral/examples/api.yaml
+++ b/factsheets/testing/spectral/examples/api.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/factsheets/testing/spectral/examples/custom-ruleset.yaml
+++ b/factsheets/testing/spectral/examples/custom-ruleset.yaml
@@ -1,0 +1,7 @@
+rules:
+  no-get-responses-without-200:
+    description: All GET requests should have a 200 response.
+    given: $.paths..get.responses
+    then:
+      field: '200'
+      function: truthy

--- a/factsheets/testing/spectral/examples/invalid.yaml
+++ b/factsheets/testing/spectral/examples/invalid.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.0
+info:
+  title: Invalid API
+  # version is missing
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          # description is missing

--- a/factsheets/testing/spectral/examples/lint.sh
+++ b/factsheets/testing/spectral/examples/lint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npx spectral lint api.yaml

--- a/factsheets/testing/step-ci/README.md
+++ b/factsheets/testing/step-ci/README.md
@@ -2,7 +2,9 @@
 
 ## Gruppe: Testing
 
-## Zweck: Step-ci ist ein Werkzeug für
+## Zweck: Step-ci ist ein Werkzeug für automatisierte API-Tests und Monitoring
+
+Step CI ist ein deklaratives Framework zum Testen und Überwachen von REST-, GraphQL- und gRPC-APIs. Tests werden in YAML oder JSON definiert und können einfach in CI/CD-Pipelines integriert werden.
 
 ## Installation (Ubuntu 24.04)
 
@@ -14,11 +16,11 @@ npm install -g stepci
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
 
-- `workflow.yml`
-- `test.js`
-- `config.json`
-- `env.env`
-- `output.txt`
+- `workflow.yml`: Definition des Test-Workflows.
+- `test.js`: Zusätzliche Testlogik in JavaScript.
+- `config.json`: Globale Konfiguration.
+- `env.env`: Umgebungsvariablen für Tests.
+- `output.txt`: Beispielhafte Testausgabe.
 
 ## Validierung
 


### PR DESCRIPTION
Added and documented a comprehensive set of tools for Swagger/OpenAPI handling:
- **Spectral**: Design-rule linting for OpenAPI/AsyncAPI.
- **Prism**: Mock servers and validation proxies.
- **Redocly CLI**: API documentation, bundling, and linting.

In addition to the new tools, the existing factsheets for **OpenAPI Generator**, **Schemathesis**, and **Step CI** were completed with proper descriptions and validation steps. Each new tool includes a detailed German factsheet and 5-10 example files (YAML specs, config files, shell scripts) as per the project strategy defined in GEMINI.md. All changes have been verified functionally and for markdown compliance.

Fixes #47

---
*PR created automatically by Jules for task [6946568060514154724](https://jules.google.com/task/6946568060514154724) started by @chatelao*