### PR TITLE
Add Swiss legal decision data sources

### DIFF
--- a/DATASOURCES.md
+++ b/DATASOURCES.md
@@ -11,6 +11,9 @@
 | Hardware/EDA | LDraw Parts Library | Standardbibliothek von LEGO-Teil-Definitionen | Download via ldview.deb/ldraw.deb | [Link](https://www.ldraw.org/) |
 | KI-Modelle | Hugging Face | Modell-Repository | `huggingface-cli download` | [Link](https://huggingface.co/) |
 | Projekt-Management | Google Jules | Interner Task-Status | API-Integration | - |
+| Rechtsprechung | Entscheidsuche.ch | Aggregator für Schweizer Gerichtsentscheide (Bund und Kantone) | Web-GUI | [Link](https://entscheidsuche.ch/) |
+| Rechtsprechung | opendata.swiss (Recht) | Portal für offene Behördendaten, inklusive Rechtsprechungs-Datasets (z.B. Baurekursgericht ZH) | CKAN API (JSON) / XML | [Link](https://opendata.swiss/de/dataset?q=Rechtsprechung) |
+| Rechtsprechung | Schweizerisches Bundesgericht (BGer) | Amtliche Sammlung der Entscheidungen des Bundesgerichts (BGE) und weitere Urteile | Web-GUI | [Link](https://www.bger.ch/index/juridiction/jurisdiction-inherit-template/jurisdiction-recht.htm) |
 | Sicherheit | NIST NVD | National Vulnerability Database | CVE-Informationen via REST-API | [Link](https://nvd.nist.gov/) |
 | Software-Entwicklung | GitHub API | Repository- und Issue-Daten | REST / GraphQL API | [Link](https://docs.github.com/en/rest) |
 | Wissen | Wikidata (SPARQL) | Semantische Abfragesprache für die Wikidata-Wissensdatenbank | SPARQL Endpunkt / Web-GUI | [Link](https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/de) |


### PR DESCRIPTION
This PR adds three key data sources for Swiss legal decisions to DATASOURCES.md:
- Entscheidsuche.ch: Aggregator for federal and cantonal decisions.
- opendata.swiss (Recht): Official open data portal's legal section.
- Schweizerisches Bundesgericht (BGer): Official source for federal supreme court decisions.

The entries are organized under a new 'Rechtsprechung' group, maintaining the repository's alphabetical sorting and documentation style.

Fixes #52

---
*PR created automatically by Jules for task [2546730880605944756](https://jules.google.com/task/2546730880605944756) started by @chatelao*