### PR TITLE
Add Human Protein Atlas to data sources

### DIFF
--- a/DATASOURCES.md
+++ b/DATASOURCES.md
@@ -2,6 +2,7 @@
 
 | Gruppe | Name | Zweck | Zugriff / Abfrage | Referenzhandbuch |
 | :--- | :--- | :--- | :--- | :--- |
+| Bioinformatik | Human Protein Atlas | Datenbank für die Lokalisierung und Expression von Proteinen in menschlichen Geweben und Zellen | Web-GUI / REST-API (JSON/XML/TSV) | [Link](https://www.proteinatlas.org/) |
 | Bioinformatik | NCBI GenBank | Umfassende Datenbank für öffentlich verfügbare DNA-Sequenzen | Web-GUI / E-Utilities API | [Link](https://www.ncbi.nlm.nih.gov/genbank/) |
 | Bioinformatik | UniProt | Datenbank für Proteinsequenzen und Funktionsinformationen | Web-GUI / REST-API | [Link](https://www.uniprot.org/) |
 | Finanzen | eCH-0196 | Schweizer Steuerauszug | XML Import | - |

--- a/DATASOURCES.md
+++ b/DATASOURCES.md
@@ -2,7 +2,7 @@
 
 | Gruppe | Name | Zweck | Zugriff / Abfrage | Referenzhandbuch |
 | :--- | :--- | :--- | :--- | :--- |
-| Bioinformatik | Human Protein Atlas | Datenbank für die Lokalisierung und Expression von Proteinen in menschlichen Geweben und Zellen | Web-GUI / REST-API (JSON/XML/TSV) | [Link](https://www.proteinatlas.org/) |
+| Bioinformatik | Human Protein Atlas | Datenbank für die Lokalisierung und Expression von Proteinen in menschlichen Geweben und Zellen | Web-GUI / [Download](https://www.proteinatlas.org/about/download) / REST-API (JSON/XML/TSV) | [Link](https://www.proteinatlas.org/) |
 | Bioinformatik | NCBI GenBank | Umfassende Datenbank für öffentlich verfügbare DNA-Sequenzen | Web-GUI / E-Utilities API | [Link](https://www.ncbi.nlm.nih.gov/genbank/) |
 | Bioinformatik | UniProt | Datenbank für Proteinsequenzen und Funktionsinformationen | Web-GUI / REST-API | [Link](https://www.uniprot.org/) |
 | Finanzen | eCH-0196 | Schweizer Steuerauszug | XML Import | - |


### PR DESCRIPTION
Added the Human Protein Atlas (HPA) to the `DATASOURCES.md` file under the `Bioinformatik` group. The entry includes a description of its purpose (database for protein localization and expression), access methods (Web-GUI and REST-API supporting JSON, XML, and TSV), and a link to the reference manual. The entry was placed at the beginning of the group to maintain alphabetical order. Verified with markdownlint.

Fixes #56

---
*PR created automatically by Jules for task [243529874300782512](https://jules.google.com/task/243529874300782512) started by @chatelao*