### PR TITLE
Three most recent completed tasks per project

### DIFF
--- a/COMPLETED_TASKS.md
+++ b/COMPLETED_TASKS.md
@@ -1,0 +1,23 @@
+# Recent Completed Tasks
+
+This report shows the three most recent completed tasks (tool installations and validations) per project (tool group), based on the verification logs in `factsheets/`.
+
+## Project: Animation
+- **synfig-studio** (2026-04-13)
+- **pencil2d** (2026-04-13)
+- **manim** (2026-04-13)
+
+## Project: App-Entwicklung
+- **react** (2026-04-13)
+- **react-native** (2026-04-13)
+- **flutter** (2026-04-13)
+
+## Project: Dokumentation
+- **wavedrom** (2026-04-13)
+- **redocly-cli** (2026-04-13)
+- **plantuml** (2026-04-13)
+
+## Project: Testing
+- **step-ci** (2026-04-13)
+- **schemathesis** (2026-04-13)
+- **prism** (2026-04-13)


### PR DESCRIPTION
The following report lists the three most recent completed tasks (successful tool installations and validations) for each project group in the repository, based on the timestamps of the `.log` files in `factsheets/`.

### Project: Animation
1. synfig-studio
2. pencil2d
3. manim

### Project: App-Entwicklung
1. react
2. react-native
3. flutter

### Project: Dokumentation
1. wavedrom
2. redocly-cli
3. plantuml

### Project: Testing
1. step-ci
2. schemathesis
3. prism

All these tasks were completed during the verification batch on 2026-04-13. Other projects (e.g., Bioinformatik, EDA) do not currently have completion logs.

Fixes #67

---
*PR created automatically by Jules for task [8830945814268204510](https://jules.google.com/task/8830945814268204510) started by @chatelao*