### PR TITLE
Create FIXME.md to track log errors and warnings

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -1,0 +1,30 @@
+# FIXME
+
+This file contains errors and warnings found in the install and test logs.
+
+## Installation Logs
+
+### [ollama.install.log](log/ollama.install.log)
+
+- `WARNING: Unable to detect NVIDIA/AMD GPU. Install lspci or lshw to automatically detect and install GPU dependencies.`
+
+## Test Logs
+
+### [apache-fop.test.log](log/apache-fop.test.log)
+
+- `[warning] /usr/bin/fop: Unable to locate serializer in /usr/share/java`
+- `[warning] /usr/bin/fop: Unable to locate xalan2 in /usr/share/java`
+- `[warning] /usr/bin/fop: Unable to locate xercesImpl in /usr/share/java`
+
+### [redocly-cli.test.log](log/redocly-cli.test.log)
+
+- `❌ Validation failed with 3 errors and 3 warnings.`
+- `Test failed for redocly-cli`
+
+### [schemathesis.test.log](log/schemathesis.test.log)
+
+- `Error: The --url option is required when specifying a schema via a file.`
+
+### [step-ci.test.log](log/step-ci.test.log)
+
+- `TypeError: Cannot convert undefined or null to object`


### PR DESCRIPTION
This change introduces a `FIXME.md` file in the root directory. This file serves as a central location to track issues identified during the tool installation and verification process. It currently includes a GPU detection warning from the Ollama installation and several test failures from various API and documentation tools.

Fixes #90

---
*PR created automatically by Jules for task [11821455365475993228](https://jules.google.com/task/11821455365475993228) started by @chatelao*