### PR TITLE
Create GROUPS.md with tool groupings and hashes

### DIFF
--- a/GROUPS.md
+++ b/GROUPS.md
@@ -1,0 +1,12 @@
+# Tool Groups
+
+| Group Hash | Tools |
+| :--- | :--- |
+| bc0e1cad | Blender, FFmpeg, ImageMagick, Krita, Manim, Pencil2D, Synfig Studio, Flutter, React, React Native |
+| 650e7cab | Biopython, BKChem, ChemFig, Jmol, PyMOL, RDKit, SeqKit, FreeCAD, LDView, MCP-FreeCAD |
+| 7dab3dde | MeshLab, OpenSCAD, Apache FOP, img2pdf, PlantUML, Redocly CLI, WaveDrom, CircuiTikZ, KiBot, cocotb |
+| c41c66db | KiCad 10.0, openFPGALoader, SKiDL, Yosys, Binwalk, cve-bin-tool, EMBA, Ghidra, GNU Binutils, Hexdump |
+| 4c8a9b89 | PANDA, Radare2, YARA, Renode, AWS CLI, AWS MCP Server, Azure CLI, Azure MCP Server, Google Cloud Run MCP, Google Cloud SDK |
+| 9fdadc99 | Vast.ai SDK, Xvfb, Ollama, vLLM, Arduino CLI, ARM GDB, Blockly, GNU Toolchain for ARM, OpenAPI Generator, OpenOCD |
+| 8e4c24e8 | Pawn Compiler, Pillow, PlatformIO Core, xmllint, XMLStarlet, xsltproc, Zeep, Hurl, Playwright, Prism |
+| 16ca16e0 | Schemathesis, Spectral, Step CI |


### PR DESCRIPTION
Created GROUPS.md by extracting tool names from TOOLS.md and grouping them into sets of 10. Each group has a unique hash generated from its members. Verified formatting with markdownlint.

Fixes #95

---
*PR created automatically by Jules for task [14180247248974933331](https://jules.google.com/task/14180247248974933331) started by @chatelao*