### PR TITLE
Add report for tools without working installations

### DIFF
--- a/INSTALL_MISSING.md
+++ b/INSTALL_MISSING.md
@@ -1,0 +1,36 @@
+# Tools ohne lauffähige Installationen
+
+Diese Liste enthält alle Werkzeuge aus `TOOLS.md`, für die keine Verifizierungsdatei (`*.hash.sha256`) im entsprechenden Factsheet-Verzeichnis gefunden wurde.
+
+| Name | Verzeichnis | Status |
+| :--- | :--- | :--- |
+| AWS CLI | `factsheets/infrastruktur/aws-cli` | Installation fehlt |
+| AWS MCP Server | `factsheets/infrastruktur/aws-mcp-server` | Installation fehlt |
+| Azure CLI | `factsheets/infrastruktur/azure-cli` | Installation fehlt |
+| Azure MCP Server | `factsheets/infrastruktur/azure-mcp-server` | Installation fehlt |
+| Binwalk | `factsheets/firmware-analyse/binwalk` | Installation fehlt |
+| EMBA | `factsheets/firmware-analyse/emba` | Installation fehlt |
+| GNU Binutils | `factsheets/firmware-analyse/gnu-binutils` | Installation fehlt |
+| Ghidra | `factsheets/firmware-analyse/ghidra` | Installation fehlt |
+| Google Cloud Run MCP | `factsheets/infrastruktur/google-cloud-run-mcp` | Installation fehlt |
+| Google Cloud SDK | `factsheets/infrastruktur/google-cloud-sdk` | Installation fehlt |
+| Hexdump | `factsheets/firmware-analyse/hexdump` | Installation fehlt |
+| JOSM | `factsheets/geodaten/josm` | Installation fehlt |
+| KiCad 10.0 | `factsheets/eda/kicad-10-0` | Installation fehlt |
+| MSSQL Express | `factsheets/datenbanken/mssql` | Installation fehlt |
+| MariaDB | `factsheets/datenbanken/mariadb` | Installation fehlt |
+| Oracle Database Free | `factsheets/datenbanken/oracle` | Installation fehlt |
+| Osmosis | `factsheets/geodaten/osmosis` | Installation fehlt |
+| PANDA | `factsheets/firmware-analyse/panda` | Installation fehlt |
+| PostGIS | `factsheets/geodaten/postgis` | Installation fehlt |
+| PostgreSQL | `factsheets/datenbanken/postgresql` | Installation fehlt |
+| Radare2 | `factsheets/firmware-analyse/radare2` | Installation fehlt |
+| Renode | `factsheets/hardware-simulation/renode` | Installation fehlt |
+| SKiDL | `factsheets/eda/skidl` | Installation fehlt |
+| Spectral | `factsheets/testing/spectral` | Installation fehlt |
+| YARA | `factsheets/firmware-analyse/yara` | Installation fehlt |
+| Yosys | `factsheets/eda/yosys` | Installation fehlt |
+| cve-bin-tool | `factsheets/firmware-analyse/cve-bin-tool` | Installation fehlt |
+| openFPGALoader | `factsheets/eda/openfpgaloader` | Installation fehlt |
+| osm2pgsql | `factsheets/geodaten/osm2pgsql` | Installation fehlt |
+| osmium-tool | `factsheets/geodaten/osmium-tool` | Installation fehlt |

--- a/INSTALL_MISSING.md
+++ b/INSTALL_MISSING.md
@@ -1,36 +1,44 @@
-# Tools ohne lauffähige Installationen
+# Tools ohne lauffähige oder verifizierte Installationen
 
-Diese Liste enthält alle Werkzeuge aus `TOOLS.md`, für die keine Verifizierungsdatei (`*.hash.sha256`) im entsprechenden Factsheet-Verzeichnis gefunden wurde.
+Diese Liste enthält alle Werkzeuge aus `TOOLS.md`, die entweder keine Verifizierungsdatei besitzen, in `FIXME.md` gelistet sind oder Fehler in den Log-Dateien aufweisen.
 
-| Name | Verzeichnis | Status |
+| Name | Verzeichnis | Grund |
 | :--- | :--- | :--- |
-| AWS CLI | `factsheets/infrastruktur/aws-cli` | Installation fehlt |
-| AWS MCP Server | `factsheets/infrastruktur/aws-mcp-server` | Installation fehlt |
-| Azure CLI | `factsheets/infrastruktur/azure-cli` | Installation fehlt |
-| Azure MCP Server | `factsheets/infrastruktur/azure-mcp-server` | Installation fehlt |
-| Binwalk | `factsheets/firmware-analyse/binwalk` | Installation fehlt |
-| EMBA | `factsheets/firmware-analyse/emba` | Installation fehlt |
-| GNU Binutils | `factsheets/firmware-analyse/gnu-binutils` | Installation fehlt |
-| Ghidra | `factsheets/firmware-analyse/ghidra` | Installation fehlt |
-| Google Cloud Run MCP | `factsheets/infrastruktur/google-cloud-run-mcp` | Installation fehlt |
-| Google Cloud SDK | `factsheets/infrastruktur/google-cloud-sdk` | Installation fehlt |
-| Hexdump | `factsheets/firmware-analyse/hexdump` | Installation fehlt |
-| JOSM | `factsheets/geodaten/josm` | Installation fehlt |
-| KiCad 10.0 | `factsheets/eda/kicad-10-0` | Installation fehlt |
-| MSSQL Express | `factsheets/datenbanken/mssql` | Installation fehlt |
-| MariaDB | `factsheets/datenbanken/mariadb` | Installation fehlt |
-| Oracle Database Free | `factsheets/datenbanken/oracle` | Installation fehlt |
-| Osmosis | `factsheets/geodaten/osmosis` | Installation fehlt |
-| PANDA | `factsheets/firmware-analyse/panda` | Installation fehlt |
-| PostGIS | `factsheets/geodaten/postgis` | Installation fehlt |
-| PostgreSQL | `factsheets/datenbanken/postgresql` | Installation fehlt |
-| Radare2 | `factsheets/firmware-analyse/radare2` | Installation fehlt |
-| Renode | `factsheets/hardware-simulation/renode` | Installation fehlt |
-| SKiDL | `factsheets/eda/skidl` | Installation fehlt |
-| Spectral | `factsheets/testing/spectral` | Installation fehlt |
-| YARA | `factsheets/firmware-analyse/yara` | Installation fehlt |
-| Yosys | `factsheets/eda/yosys` | Installation fehlt |
-| cve-bin-tool | `factsheets/firmware-analyse/cve-bin-tool` | Installation fehlt |
-| openFPGALoader | `factsheets/eda/openfpgaloader` | Installation fehlt |
-| osm2pgsql | `factsheets/geodaten/osm2pgsql` | Installation fehlt |
-| osmium-tool | `factsheets/geodaten/osmium-tool` | Installation fehlt |
+| AWS CLI | `factsheets/infrastruktur/aws-cli` | Verifizierungsdatei fehlt (.hash.sha256) |
+| AWS MCP Server | `factsheets/infrastruktur/aws-mcp-server` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Azure CLI | `factsheets/infrastruktur/azure-cli` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Azure MCP Server | `factsheets/infrastruktur/azure-mcp-server` | Verifizierungsdatei fehlt (.hash.sha256) |
+| BKChem | `factsheets/bioinformatik/bkchem` | In FIXME.md gelistet; Test-Fehler: Python Traceback detected |
+| Binwalk | `factsheets/firmware-analyse/binwalk` | Verifizierungsdatei fehlt (.hash.sha256) |
+| ChemFig | `factsheets/bioinformatik/chemfig` | In FIXME.md gelistet; Test-Fehler: ! LaTeX Error: File `standalone.cls' not found. |
+| EMBA | `factsheets/firmware-analyse/emba` | Verifizierungsdatei fehlt (.hash.sha256) |
+| FreeCAD | `factsheets/cad-3d/freecad` | In FIXME.md gelistet |
+| GNU Binutils | `factsheets/firmware-analyse/gnu-binutils` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Ghidra | `factsheets/firmware-analyse/ghidra` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Google Cloud Run MCP | `factsheets/infrastruktur/google-cloud-run-mcp` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Google Cloud SDK | `factsheets/infrastruktur/google-cloud-sdk` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Gqrx SDR | `factsheets/funktechnik/gqrx-sdr` | In FIXME.md gelistet |
+| Hexdump | `factsheets/firmware-analyse/hexdump` | Verifizierungsdatei fehlt (.hash.sha256) |
+| JOSM | `factsheets/geodaten/josm` | Verifizierungsdatei fehlt (.hash.sha256) |
+| KiCad 10.0 | `factsheets/eda/kicad-10-0` | Verifizierungsdatei fehlt (.hash.sha256) |
+| LDView | `factsheets/cad-3d/ldview` | In FIXME.md gelistet; Test-Fehler: libEGL warning: DRI3 error: Could not get DRI3 device |
+| MCP-FreeCAD | `factsheets/cad-3d/mcp-freecad` | In FIXME.md gelistet |
+| MSSQL Express | `factsheets/datenbanken/mssql` | Verifizierungsdatei fehlt (.hash.sha256) |
+| MariaDB | `factsheets/datenbanken/mariadb` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Oracle Database Free | `factsheets/datenbanken/oracle` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Osmosis | `factsheets/geodaten/osmosis` | Verifizierungsdatei fehlt (.hash.sha256) |
+| PANDA | `factsheets/firmware-analyse/panda` | Verifizierungsdatei fehlt (.hash.sha256) |
+| PostGIS | `factsheets/geodaten/postgis` | Verifizierungsdatei fehlt (.hash.sha256) |
+| PostgreSQL | `factsheets/datenbanken/postgresql` | Verifizierungsdatei fehlt (.hash.sha256) |
+| PyMOL | `factsheets/bioinformatik/pymol` | In FIXME.md gelistet; Test-Fehler: Python Traceback detected |
+| Radare2 | `factsheets/firmware-analyse/radare2` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Renode | `factsheets/hardware-simulation/renode` | Verifizierungsdatei fehlt (.hash.sha256) |
+| SKiDL | `factsheets/eda/skidl` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Schemathesis | `factsheets/testing/schemathesis` | In FIXME.md gelistet; Test-Fehler: Connection failed |
+| Spectral | `factsheets/testing/spectral` | Verifizierungsdatei fehlt (.hash.sha256) |
+| YARA | `factsheets/firmware-analyse/yara` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Yosys | `factsheets/eda/yosys` | Verifizierungsdatei fehlt (.hash.sha256) |
+| cve-bin-tool | `factsheets/firmware-analyse/cve-bin-tool` | Verifizierungsdatei fehlt (.hash.sha256) |
+| openFPGALoader | `factsheets/eda/openfpgaloader` | Verifizierungsdatei fehlt (.hash.sha256) |
+| osm2pgsql | `factsheets/geodaten/osm2pgsql` | Verifizierungsdatei fehlt (.hash.sha256) |
+| osmium-tool | `factsheets/geodaten/osmium-tool` | Verifizierungsdatei fehlt (.hash.sha256) |


### PR DESCRIPTION
Identified all tools from `TOOLS.md` that do not have a verified installation (missing `*.hash.sha256` files) and generated a sorted Markdown report in `INSTALL_MISSING.md`.

Fixes #140

---
*PR created automatically by Jules for task [17553076148074913312](https://jules.google.com/task/17553076148074913312) started by @chatelao*