### PR TITLE
Update list of tools with missing verified installers

### DIFF
--- a/INSTALL_MISSING.md
+++ b/INSTALL_MISSING.md
@@ -8,32 +8,18 @@ Diese Liste enthält alle Werkzeuge aus `TOOLS.md`, die entweder keine Verifizie
 | AWS MCP Server | `factsheets/infrastruktur/aws-mcp-server` | Verifizierungsdatei fehlt (.hash.sha256) |
 | Azure CLI | `factsheets/infrastruktur/azure-cli` | Verifizierungsdatei fehlt (.hash.sha256) |
 | Azure MCP Server | `factsheets/infrastruktur/azure-mcp-server` | Verifizierungsdatei fehlt (.hash.sha256) |
-| BKChem | `factsheets/bioinformatik/bkchem` | In FIXME.md gelistet; Test-Fehler: Python Traceback detected |
-| Binwalk | `factsheets/firmware-analyse/binwalk` | Verifizierungsdatei fehlt (.hash.sha256) |
-| ChemFig | `factsheets/bioinformatik/chemfig` | In FIXME.md gelistet; Test-Fehler: ! LaTeX Error: File `standalone.cls' not found. |
-| EMBA | `factsheets/firmware-analyse/emba` | Verifizierungsdatei fehlt (.hash.sha256) |
+| BKChem | `factsheets/bioinformatik/bkchem` | Log-Fehler: ModuleNotFoundError, Python Traceback |
+| ChemFig | `factsheets/bioinformatik/chemfig` | Log-Fehler: LaTeX Error |
 | FreeCAD | `factsheets/cad-3d/freecad` | In FIXME.md gelistet |
-| GNU Binutils | `factsheets/firmware-analyse/gnu-binutils` | Verifizierungsdatei fehlt (.hash.sha256) |
-| Ghidra | `factsheets/firmware-analyse/ghidra` | Verifizierungsdatei fehlt (.hash.sha256) |
+| Ghidra | `factsheets/firmware-analyse/ghidra` | Log-Fehler: Fehlgeschlagen |
 | Google Cloud Run MCP | `factsheets/infrastruktur/google-cloud-run-mcp` | Verifizierungsdatei fehlt (.hash.sha256) |
 | Google Cloud SDK | `factsheets/infrastruktur/google-cloud-sdk` | Verifizierungsdatei fehlt (.hash.sha256) |
-| Gqrx SDR | `factsheets/funktechnik/gqrx-sdr` | In FIXME.md gelistet |
-| Hexdump | `factsheets/firmware-analyse/hexdump` | Verifizierungsdatei fehlt (.hash.sha256) |
-| KiCad 10.0 | `factsheets/eda/kicad-10-0` | Verifizierungsdatei fehlt (.hash.sha256) |
-| LDView | `factsheets/cad-3d/ldview` | In FIXME.md gelistet; Test-Fehler: libEGL warning: DRI3 error: Could not get DRI3 device |
-| MCP-FreeCAD | `factsheets/cad-3d/mcp-freecad` | In FIXME.md gelistet |
 | MSSQL Express | `factsheets/datenbanken/mssql` | Verifizierungsdatei fehlt (.hash.sha256) |
 | MariaDB | `factsheets/datenbanken/mariadb` | Verifizierungsdatei fehlt (.hash.sha256) |
 | Oracle Database Free | `factsheets/datenbanken/oracle` | Verifizierungsdatei fehlt (.hash.sha256) |
 | PANDA | `factsheets/firmware-analyse/panda` | Verifizierungsdatei fehlt (.hash.sha256) |
 | PostgreSQL | `factsheets/datenbanken/postgresql` | Verifizierungsdatei fehlt (.hash.sha256) |
-| PyMOL | `factsheets/bioinformatik/pymol` | In FIXME.md gelistet; Test-Fehler: Python Traceback detected |
-| Radare2 | `factsheets/firmware-analyse/radare2` | Verifizierungsdatei fehlt (.hash.sha256) |
+| PyMOL | `factsheets/bioinformatik/pymol` | Log-Fehler: ModuleNotFoundError, Python Traceback |
 | Renode | `factsheets/hardware-simulation/renode` | Verifizierungsdatei fehlt (.hash.sha256) |
-| SKiDL | `factsheets/eda/skidl` | Verifizierungsdatei fehlt (.hash.sha256) |
-| Schemathesis | `factsheets/testing/schemathesis` | In FIXME.md gelistet; Test-Fehler: Connection failed |
+| Schemathesis | `factsheets/testing/schemathesis` | Log-Fehler: Fehlgeschlagen |
 | Spectral | `factsheets/testing/spectral` | Verifizierungsdatei fehlt (.hash.sha256) |
-| YARA | `factsheets/firmware-analyse/yara` | Verifizierungsdatei fehlt (.hash.sha256) |
-| Yosys | `factsheets/eda/yosys` | Verifizierungsdatei fehlt (.hash.sha256) |
-| cve-bin-tool | `factsheets/firmware-analyse/cve-bin-tool` | Verifizierungsdatei fehlt (.hash.sha256) |
-| openFPGALoader | `factsheets/eda/openfpgaloader` | Verifizierungsdatei fehlt (.hash.sha256) |


### PR DESCRIPTION
I have updated the `INSTALL_MISSING.md` file to provide an accurate and up-to-date list of tools that are missing verified installers or have failing processes. 

Key changes include:
- **Programmatic Audit:** I used a custom script to cross-reference tools in `TOOLS.md` against the presence of `.hash.sha256` files, entries in `FIXME.md`, and fatal error patterns in the `log/` directory.
- **Improved Accuracy:** The "Grund" (Reason) column now includes more specific technical details from logs where available (e.g., distinguishing between a general failure and a `ModuleNotFoundError`).
- **Repository Sync:** Removed tools from the list that are no longer missing verification or are now passing their tests, ensuring the tracking document matches the actual state of the codebase.
- **Cleanup:** Ensured no out-of-scope changes or transient scripts were included in the final submission.

Fixes #161

---
*PR created automatically by Jules for task [14321966540409683341](https://jules.google.com/task/14321966540409683341) started by @chatelao*