### PR TITLE
Fix Ghidra installation verification

### DIFF
--- a/INSTALL_MISSING.md
+++ b/INSTALL_MISSING.md
@@ -11,7 +11,6 @@ Diese Liste enthält alle Werkzeuge aus `TOOLS.md`, die entweder keine Verifizie
 | BKChem | `factsheets/bioinformatik/bkchem` | Log-Fehler: ModuleNotFoundError, Python Traceback |
 | ChemFig | `factsheets/bioinformatik/chemfig` | Log-Fehler: LaTeX Error |
 | FreeCAD | `factsheets/cad-3d/freecad` | In FIXME.md gelistet |
-| Ghidra | `factsheets/firmware-analyse/ghidra` | Log-Fehler: Fehlgeschlagen |
 | Google Cloud Run MCP | `factsheets/infrastruktur/google-cloud-run-mcp` | Verifizierungsdatei fehlt (.hash.sha256) |
 | Google Cloud SDK | `factsheets/infrastruktur/google-cloud-sdk` | Verifizierungsdatei fehlt (.hash.sha256) |
 | MSSQL Express | `factsheets/datenbanken/mssql` | Verifizierungsdatei fehlt (.hash.sha256) |

--- a/factsheets/firmware-analyse/ghidra/README.md
+++ b/factsheets/firmware-analyse/ghidra/README.md
@@ -47,5 +47,5 @@ Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
 Ghidra headless Modus verifizieren:
 
 ```bash
-./ghidra_12.0.4_PUBLIC/support/analyzeHeadless . temp -noanalysis -deleteProject
+./ghidra_12.0.4_PUBLIC/support/analyzeHeadless . temp -noanalysis -deleteProject -preScript HelloWorldScript.java
 ```

--- a/factsheets/firmware-analyse/ghidra/ghidra_run_test.sh
+++ b/factsheets/firmware-analyse/ghidra/ghidra_run_test.sh
@@ -3,4 +3,4 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 cd "$(dirname "$0")"
 
-./ghidra_12.0.4_PUBLIC/support/analyzeHeadless . temp -noanalysis -deleteProject
+./ghidra_12.0.4_PUBLIC/support/analyzeHeadless . temp -noanalysis -deleteProject -preScript HelloWorldScript.java


### PR DESCRIPTION
The Ghidra installation verification was failing because the `analyzeHeadless` command was invoked without any work to perform (no import, process, or script), leading to an exit code of 1. By adding `-preScript HelloWorldScript.java`, a built-in script is executed, verifying that the Ghidra runtime and script compiler are fully functional.

Changes:
- Updated `factsheets/firmware-analyse/ghidra/README.md` with the functional verification command.
- Regenerated `factsheets/firmware-analyse/ghidra/ghidra_run_test.sh` using `generate_tool_scripts.py`.
- Removed Ghidra from `INSTALL_MISSING.md` as it is now functional and verified.

Fixes #163

---
*PR created automatically by Jules for task [14668086938187147684](https://jules.google.com/task/14668086938187147684) started by @chatelao*