### PR TITLE
Add "Hello World" example snippets to all factsheets

### DIFF
--- a/factsheets/animation/blender/README.md
+++ b/factsheets/animation/blender/README.md
@@ -19,6 +19,13 @@ sudo apt update
 sudo apt install blender
 ```
 
+## Hello World
+
+```python
+import bpy
+bpy.ops.mesh.primitive_cube_add()
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/animation/ffmpeg/README.md
+++ b/factsheets/animation/ffmpeg/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install ffmpeg
 ```
 
+## Hello World
+
+```bash
+ffmpeg -version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/animation/imagemagick/README.md
+++ b/factsheets/animation/imagemagick/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install imagemagick
 ```
 
+## Hello World
+
+```bash
+convert -size 100x100 xc:white -draw "text 10,50 'Hello World'" hello.png
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/animation/krita/README.md
+++ b/factsheets/animation/krita/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install krita
 ```
 
+## Hello World
+
+```bash
+krita --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/animation/manim/README.md
+++ b/factsheets/animation/manim/README.md
@@ -20,6 +20,16 @@ sudo apt install ffmpeg libcairo2-dev libpango1.0-dev
 pip install manim
 ```
 
+## Hello World
+
+```python
+from manim import *
+
+class HelloWorld(Scene):
+    def construct(self):
+        self.add(Text("Hello World"))
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/animation/pencil2d/README.md
+++ b/factsheets/animation/pencil2d/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install pencil2d
 ```
 
+## Hello World
+
+```bash
+pencil2d --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/animation/synfig-studio/README.md
+++ b/factsheets/animation/synfig-studio/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install synfigstudio
 ```
 
+## Hello World
+
+```bash
+synfig --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/app-entwicklung/flutter/README.md
+++ b/factsheets/app-entwicklung/flutter/README.md
@@ -23,6 +23,14 @@ export PATH="$PATH:/opt/flutter/bin"
 flutter doctor
 ```
 
+## Hello World
+
+```dart
+import 'package:flutter/material.dart';
+
+void main() => runApp(Text('Hello World'));
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/app-entwicklung/react-native/README.md
+++ b/factsheets/app-entwicklung/react-native/README.md
@@ -22,6 +22,15 @@ React Native erfordert Node.js und JDK. Die CLI kann über npm ausgeführt werde
 npx react-native init MyProject
 ```
 
+## Hello World
+
+```jsx
+import React from 'react';
+import { Text } from 'react-native';
+
+export default () => <Text>Hello World</Text>;
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/app-entwicklung/react/README.md
+++ b/factsheets/app-entwicklung/react/README.md
@@ -28,6 +28,15 @@ Oder ein neues Projekt erstellen:
 npx create-react-app my-app
 ```
 
+## Hello World
+
+```jsx
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+ReactDOM.render(<h1>Hello, world!</h1>, document.getElementById('root'));
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/app-entwicklung/spring-boot/README.md
+++ b/factsheets/app-entwicklung/spring-boot/README.md
@@ -26,6 +26,16 @@ sudo ln -sf /opt/spring-boot-cli/bin/spring /usr/local/bin/spring
 rm spring-boot-cli.tar.gz
 ```
 
+## Hello World
+
+```java
+@RestController
+class Hello {
+    @GetMapping("/")
+    String hi() { return "Hello World"; }
+}
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/bioinformatik/biopython/README.md
+++ b/factsheets/bioinformatik/biopython/README.md
@@ -19,6 +19,13 @@ sudo apt update
 sudo apt install python3-biopython
 ```
 
+## Hello World
+
+```python
+from Bio.Seq import Seq
+print(Seq("AGT").reverse_complement())
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/bioinformatik/bkchem/README.md
+++ b/factsheets/bioinformatik/bkchem/README.md
@@ -23,6 +23,12 @@ sudo apt update
 sudo apt install bkchem
 ```
 
+## Hello World
+
+```bash
+bkchem --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/bioinformatik/chemfig/README.md
+++ b/factsheets/bioinformatik/chemfig/README.md
@@ -23,6 +23,12 @@ sudo apt update
 sudo apt install texlive-science texlive-latex-extra texlive-fonts-recommended
 ```
 
+## Hello World
+
+```latex
+\chemfig{H-O-H}
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/bioinformatik/jmol/README.md
+++ b/factsheets/bioinformatik/jmol/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install jmol
 ```
 
+## Hello World
+
+```bash
+jmol -n -g 100x100 -J "load $caffeine; write image hello.png"
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/bioinformatik/pymol/README.md
+++ b/factsheets/bioinformatik/pymol/README.md
@@ -22,6 +22,13 @@ sudo sed -i 's/^from imp import find_module/import importlib.util/' /usr/lib/pyt
 sudo sed -i "s/find_module('pymol')\[1\]/importlib.util.find_spec('pymol').submodule_search_locations[0]/" /usr/lib/python3/dist-packages/pymol/__init__.py
 ```
 
+## Hello World
+
+```python
+import pymol
+pymol.finish_launching()
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/bioinformatik/rdkit/README.md
+++ b/factsheets/bioinformatik/rdkit/README.md
@@ -19,6 +19,13 @@ sudo apt update
 sudo apt install python3-rdkit
 ```
 
+## Hello World
+
+```python
+from rdkit import Chem
+print(Chem.MolToSmiles(Chem.MolFromSmiles('C')))
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/bioinformatik/seqkit/README.md
+++ b/factsheets/bioinformatik/seqkit/README.md
@@ -18,6 +18,12 @@ sudo apt update
 sudo apt install seqkit
 ```
 
+## Hello World
+
+```bash
+seqkit version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/cad-3d/freecad/README.md
+++ b/factsheets/cad-3d/freecad/README.md
@@ -18,6 +18,13 @@
 sudo add-apt-repository ppa:freecad-maintainers/freecad-stable; sudo apt update; sudo apt install freecad
 ```
 
+## Hello World
+
+```python
+import FreeCAD
+FreeCAD.Console.PrintMessage("Hello World\n")
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/cad-3d/ldview/README.md
+++ b/factsheets/cad-3d/ldview/README.md
@@ -20,6 +20,12 @@ sudo apt install -y libosmesa6
 curl -L http://download.opensuse.org/repositories/home:/pbartfai/xUbuntu_24.04/amd64/ldview-osmesa_4.7-1_amd64.deb -o ldview.deb; sudo apt install ./ldview.deb
 ```
 
+## Hello World
+
+```bash
+ldview --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/cad-3d/mcp-freecad/README.md
+++ b/factsheets/cad-3d/mcp-freecad/README.md
@@ -18,6 +18,12 @@ git clone https://github.com/jango-blockchained/mcp-freecad.git
 cd mcp-freecad && pip install -r requirements.txt
 ```
 
+## Hello World
+
+```bash
+npx mcp-freecad
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/cad-3d/meshlab/README.md
+++ b/factsheets/cad-3d/meshlab/README.md
@@ -18,6 +18,12 @@
 sudo apt install meshlab
 ```
 
+## Hello World
+
+```bash
+meshlabserver -version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/cad-3d/openscad/README.md
+++ b/factsheets/cad-3d/openscad/README.md
@@ -18,6 +18,12 @@
 sudo apt install openscad
 ```
 
+## Hello World
+
+```openscad
+cube([10,10,10]);
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/datenbanken/mariadb/README.md
+++ b/factsheets/datenbanken/mariadb/README.md
@@ -21,6 +21,12 @@ sudo apt update
 sudo apt install mariadb-server
 ```
 
+## Hello World
+
+```sql
+SELECT 'Hello World';
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/datenbanken/mssql/README.md
+++ b/factsheets/datenbanken/mssql/README.md
@@ -23,6 +23,12 @@ sudo apt update
 sudo apt install mssql-server
 ```
 
+## Hello World
+
+```sql
+SELECT 'Hello World';
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/datenbanken/oracle/README.md
+++ b/factsheets/datenbanken/oracle/README.md
@@ -25,6 +25,12 @@ docker pull container-registry.oracle.com/database/free:latest
 Alternativ finden Sie die Downloads für andere Linux-Distributionen hier:
 [Download Link](https://www.oracle.com/database/technologies/oracle-database-free-downloads.html)
 
+## Hello World
+
+```sql
+SELECT 'Hello World' FROM dual;
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/datenbanken/postgresql/README.md
+++ b/factsheets/datenbanken/postgresql/README.md
@@ -21,6 +21,12 @@ sudo apt update
 sudo apt install postgresql
 ```
 
+## Hello World
+
+```sql
+SELECT 'Hello World';
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/dokumentation/apache-fop/README.md
+++ b/factsheets/dokumentation/apache-fop/README.md
@@ -18,6 +18,12 @@
 sudo apt install fop
 ```
 
+## Hello World
+
+```xml
+<fo:block>Hello World</fo:block>
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/dokumentation/img2pdf/README.md
+++ b/factsheets/dokumentation/img2pdf/README.md
@@ -17,6 +17,12 @@
 sudo apt install img2pdf
 ```
 
+## Hello World
+
+```bash
+img2pdf -o out.pdf in.jpg
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/dokumentation/plantuml/README.md
+++ b/factsheets/dokumentation/plantuml/README.md
@@ -18,6 +18,14 @@
 sudo apt install plantuml
 ```
 
+## Hello World
+
+```plantuml
+@startuml
+Alice -> Bob: Hello World
+@enduml
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/dokumentation/redocly-cli/README.md
+++ b/factsheets/dokumentation/redocly-cli/README.md
@@ -22,6 +22,12 @@ generieren und APIs in der Vorschau anzeigen.
 npm install @redocly/cli
 ```
 
+## Hello World
+
+```bash
+redocly lint openapi.yaml
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/dokumentation/wavedrom/README.md
+++ b/factsheets/dokumentation/wavedrom/README.md
@@ -17,6 +17,12 @@
 npm install wavedrom
 ```
 
+## Hello World
+
+```json
+{ "signal": [ { "name": "clk", "wave": "p....." } ] }
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/eda/circuitikz/README.md
+++ b/factsheets/eda/circuitikz/README.md
@@ -18,6 +18,14 @@
 sudo apt install texlive-pictures
 ```
 
+## Hello World
+
+```latex
+\begin{circuitikz}
+\draw (0,0) to[R=1<\ohm>] (2,0);
+\end{circuitikz}
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/eda/cocotb/README.md
+++ b/factsheets/eda/cocotb/README.md
@@ -20,6 +20,14 @@ das Testen von VHDL- und Verilog-Hardware-Designs mit Python.
 pip install cocotb
 ```
 
+## Hello World
+
+```python
+@cocotb.test()
+async def test(dut):
+    dut._log.info("Hello World")
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/eda/kibot/README.md
+++ b/factsheets/eda/kibot/README.md
@@ -17,6 +17,12 @@
 pip install kibot
 ```
 
+## Hello World
+
+```bash
+kibot --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/eda/kicad-10-0/README.md
+++ b/factsheets/eda/kicad-10-0/README.md
@@ -18,6 +18,12 @@
 sudo add-apt-repository ppa:kicad/kicad-10.0-releases; sudo apt update; sudo apt install --install-recommends kicad
 ```
 
+## Hello World
+
+```bash
+kicad --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/eda/openfpgaloader/README.md
+++ b/factsheets/eda/openfpgaloader/README.md
@@ -21,6 +21,12 @@ Gowin, Efinix, Anlogic) und verschiedene Programmierkabel (JTAG, USB).
 sudo apt install openfpgaloader
 ```
 
+## Hello World
+
+```bash
+openFPGALoader --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/eda/skidl/README.md
+++ b/factsheets/eda/skidl/README.md
@@ -17,6 +17,14 @@
 pip install skidl
 ```
 
+## Hello World
+
+```python
+from skidl import *
+r1 = Part("Device", "R")
+print("Hello SKiDL")
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/eda/yosys/README.md
+++ b/factsheets/eda/yosys/README.md
@@ -22,6 +22,12 @@ Hardware-Beschreibungen.
 sudo apt install yosys
 ```
 
+## Hello World
+
+```bash
+yosys -p "help"
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/firmware-analyse/binwalk/README.md
+++ b/factsheets/firmware-analyse/binwalk/README.md
@@ -18,6 +18,12 @@
 sudo apt install binwalk
 ```
 
+## Hello World
+
+```bash
+binwalk firmware.bin
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/firmware-analyse/cve-bin-tool/README.md
+++ b/factsheets/firmware-analyse/cve-bin-tool/README.md
@@ -17,6 +17,12 @@
 pip install cve-bin-tool
 ```
 
+## Hello World
+
+```bash
+cve-bin-tool .
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/firmware-analyse/emba/README.md
+++ b/factsheets/firmware-analyse/emba/README.md
@@ -17,6 +17,12 @@
 git clone https://github.com/e-m-b-a/emba.git
 ```
 
+## Hello World
+
+```bash
+./emba -h
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/firmware-analyse/ghidra/README.md
+++ b/factsheets/firmware-analyse/ghidra/README.md
@@ -20,6 +20,12 @@ wget https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_1
 unzip ghidra_12.0.4_PUBLIC_20260303.zip
 ```
 
+## Hello World
+
+```bash
+./analyzeHeadless . temp -preScript HelloWorldScript.java
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/firmware-analyse/gnu-binutils/README.md
+++ b/factsheets/firmware-analyse/gnu-binutils/README.md
@@ -18,6 +18,12 @@
 sudo apt install binutils
 ```
 
+## Hello World
+
+```bash
+objdump -h file.o
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/firmware-analyse/hexdump/README.md
+++ b/factsheets/firmware-analyse/hexdump/README.md
@@ -18,6 +18,12 @@
 sudo apt install bsdextrautils
 ```
 
+## Hello World
+
+```bash
+echo "Hello" | hexdump -C
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/firmware-analyse/panda/README.md
+++ b/factsheets/firmware-analyse/panda/README.md
@@ -17,6 +17,12 @@
 git clone https://github.com/panda-re/panda.git
 ```
 
+## Hello World
+
+```bash
+panda-system-x86_64 --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/firmware-analyse/radare2/README.md
+++ b/factsheets/firmware-analyse/radare2/README.md
@@ -18,6 +18,12 @@
 sudo apt install radare2
 ```
 
+## Hello World
+
+```bash
+r2 -c "pd 10" /bin/ls
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/firmware-analyse/yara/README.md
+++ b/factsheets/firmware-analyse/yara/README.md
@@ -18,6 +18,12 @@
 sudo apt install yara
 ```
 
+## Hello World
+
+```yara
+rule hello { condition: true }
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/funktechnik/gnuradio/README.md
+++ b/factsheets/funktechnik/gnuradio/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install -y gnuradio
 ```
 
+## Hello World
+
+```bash
+gnuradio-config-info --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/funktechnik/gqrx-sdr/README.md
+++ b/factsheets/funktechnik/gqrx-sdr/README.md
@@ -20,6 +20,12 @@ sudo touch /etc/modules
 sudo apt install -y gqrx-sdr
 ```
 
+## Hello World
+
+```bash
+gqrx --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/funktechnik/inspectrum/README.md
+++ b/factsheets/funktechnik/inspectrum/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install -y inspectrum
 ```
 
+## Hello World
+
+```bash
+inspectrum --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/funktechnik/node-red/README.md
+++ b/factsheets/funktechnik/node-red/README.md
@@ -18,6 +18,12 @@
 sudo npm install -g --unsafe-perm node-red
 ```
 
+## Hello World
+
+```bash
+node-red --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/funktechnik/rtl-sdr/README.md
+++ b/factsheets/funktechnik/rtl-sdr/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install -y rtl-sdr
 ```
 
+## Hello World
+
+```bash
+rtl_test
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/funktechnik/urh/README.md
+++ b/factsheets/funktechnik/urh/README.md
@@ -18,6 +18,12 @@
 pip install urh
 ```
 
+## Hello World
+
+```bash
+urh --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/geodaten/josm/README.md
+++ b/factsheets/geodaten/josm/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install -y josm
 ```
 
+## Hello World
+
+```bash
+josm --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/geodaten/osm2pgsql/README.md
+++ b/factsheets/geodaten/osm2pgsql/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install -y osm2pgsql
 ```
 
+## Hello World
+
+```bash
+osm2pgsql --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/geodaten/osmium-tool/README.md
+++ b/factsheets/geodaten/osmium-tool/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install -y osmium-tool
 ```
 
+## Hello World
+
+```bash
+osmium --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/geodaten/osmosis/README.md
+++ b/factsheets/geodaten/osmosis/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install -y osmosis
 ```
 
+## Hello World
+
+```bash
+osmosis --help
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/geodaten/postgis/README.md
+++ b/factsheets/geodaten/postgis/README.md
@@ -19,6 +19,12 @@ sudo apt update
 sudo apt install -y postgis postgresql-16-postgis-3 gdal-bin
 ```
 
+## Hello World
+
+```sql
+SELECT PostGIS_Full_Version();
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/hardware-simulation/renode/README.md
+++ b/factsheets/hardware-simulation/renode/README.md
@@ -20,6 +20,12 @@ sudo apt-get install -y ./renode_1.16.1_amd64.deb
 rm renode_1.16.1_amd64.deb
 ```
 
+## Hello World
+
+```bash
+renode -e "echo 'Hello World'; quit"
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/infrastruktur/aws-cli/README.md
+++ b/factsheets/infrastruktur/aws-cli/README.md
@@ -25,6 +25,12 @@ unzip awscliv2.zip
 sudo ./aws/install
 ```
 
+## Hello World
+
+```bash
+aws --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/infrastruktur/aws-mcp-server/README.md
+++ b/factsheets/infrastruktur/aws-mcp-server/README.md
@@ -24,6 +24,12 @@ Voraussetzung: [uv](https://github.com/astral-sh/uv) muss installiert sein.
 uvx awslabs.aws-api-mcp-server@latest
 ```
 
+## Hello World
+
+```bash
+npx @awslabs/aws-api-mcp-server
+```
+
 ## Validierung
 
 Der Server wird normalerweise über einen MCP-Client konfiguriert. Manuell kann

--- a/factsheets/infrastruktur/azure-cli/README.md
+++ b/factsheets/infrastruktur/azure-cli/README.md
@@ -22,6 +22,12 @@ steuern.
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 ```
 
+## Hello World
+
+```bash
+az --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/infrastruktur/azure-mcp-server/README.md
+++ b/factsheets/infrastruktur/azure-mcp-server/README.md
@@ -23,6 +23,12 @@ Voraussetzung: [uv](https://github.com/astral-sh/uv) muss installiert sein.
 uvx --from msmcp-azure azmcp server start
 ```
 
+## Hello World
+
+```bash
+npx @microsoft/azmcp
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/infrastruktur/docker-compose/README.md
+++ b/factsheets/infrastruktur/docker-compose/README.md
@@ -18,6 +18,12 @@ sudo apt update
 sudo apt install docker-compose-plugin
 ```
 
+## Hello World
+
+```bash
+docker-compose --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/infrastruktur/docker/README.md
+++ b/factsheets/infrastruktur/docker/README.md
@@ -18,6 +18,12 @@ sudo apt update
 sudo apt install docker-ce
 ```
 
+## Hello World
+
+```bash
+docker run hello-world
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/infrastruktur/google-cloud-run-mcp/README.md
+++ b/factsheets/infrastruktur/google-cloud-run-mcp/README.md
@@ -23,6 +23,12 @@ sein.
 npx -y @google-cloud/cloud-run-mcp
 ```
 
+## Hello World
+
+```bash
+npx @google-cloud/cloud-run-mcp
+```
+
 ## Validierung
 
 Der Server wird normalerweise über einen MCP-Client konfiguriert. Manuell kann

--- a/factsheets/infrastruktur/google-cloud-sdk/README.md
+++ b/factsheets/infrastruktur/google-cloud-sdk/README.md
@@ -23,6 +23,12 @@ exec -l $SHELL
 gcloud init
 ```
 
+## Hello World
+
+```bash
+gcloud --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/infrastruktur/kubernetes/README.md
+++ b/factsheets/infrastruktur/kubernetes/README.md
@@ -23,6 +23,12 @@ sudo apt update
 sudo apt install -y kubectl
 ```
 
+## Hello World
+
+```bash
+kubectl version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/infrastruktur/vast-ai-sdk/README.md
+++ b/factsheets/infrastruktur/vast-ai-sdk/README.md
@@ -22,6 +22,12 @@ Daten/Modelle auf Remote-GPUs zu übertragen.
 pip install vastai
 ```
 
+## Hello World
+
+```bash
+vastai --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/infrastruktur/xvfb/README.md
+++ b/factsheets/infrastruktur/xvfb/README.md
@@ -24,6 +24,12 @@ Bioinformatik-Viewer) in Headless-Umgebungen (CI/CD, Server) validieren müssen.
 sudo apt install xvfb
 ```
 
+## Hello World
+
+```bash
+Xvfb :99 &
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/ki-inferenz/ollama/README.md
+++ b/factsheets/ki-inferenz/ollama/README.md
@@ -24,6 +24,12 @@ die lokale Inferenz benötigen.
 curl -fsSL https://ollama.com/install.sh | sh
 ```
 
+## Hello World
+
+```bash
+ollama run llama3 "Hello World"
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/ki-inferenz/vllm/README.md
+++ b/factsheets/ki-inferenz/vllm/README.md
@@ -23,6 +23,12 @@ bereitzustellen.
 pip install vllm
 ```
 
+## Hello World
+
+```bash
+python3 -m vllm.entrypoints.openai.api_server
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/programmierung/ant/README.md
+++ b/factsheets/programmierung/ant/README.md
@@ -20,6 +20,12 @@ sudo apt update
 sudo apt install ant
 ```
 
+## Hello World
+
+```xml
+<project><target name="hello"><echo>Hello World</echo></target></project>
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/programmierung/arduino-cli/README.md
+++ b/factsheets/programmierung/arduino-cli/README.md
@@ -24,6 +24,12 @@ angewiesen zu sein.
 curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/.local/bin sh
 ```
 
+## Hello World
+
+```bash
+arduino-cli version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/programmierung/arm-gdb/README.md
+++ b/factsheets/programmierung/arm-gdb/README.md
@@ -22,6 +22,12 @@ Cortex-R Mikrocontroller.
 sudo apt install gdb-multiarch
 ```
 
+## Hello World
+
+```bash
+arm-none-eabi-gdb --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/programmierung/blockly/README.md
+++ b/factsheets/programmierung/blockly/README.md
@@ -23,6 +23,12 @@ zu übersetzen oder um komplexe Logikstrukturen visuell darzustellen.
 npm install blockly
 ```
 
+## Hello World
+
+```javascript
+Blockly.inject('blocklyDiv', {toolbox: toolbox});
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/programmierung/composer/README.md
+++ b/factsheets/programmierung/composer/README.md
@@ -19,6 +19,12 @@ Composer ist ein Abhängigkeitsmanager für PHP, der es ermöglicht, Bibliotheke
 sudo apt install composer
 ```
 
+## Hello World
+
+```bash
+composer --version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/programmierung/gnu-toolchain-for-arm/README.md
+++ b/factsheets/programmierung/gnu-toolchain-for-arm/README.md
@@ -23,6 +23,12 @@ Embedded-Entwicklung auf Linux-Systemen.
 sudo apt install gcc-arm-none-eabi
 ```
 
+## Hello World
+
+```bash
+arm-none-eabi-gcc --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/programmierung/java/README.md
+++ b/factsheets/programmierung/java/README.md
@@ -20,6 +20,16 @@ sudo apt update
 sudo apt install openjdk-21-jdk
 ```
 
+## Hello World
+
+```java
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/programmierung/maven/README.md
+++ b/factsheets/programmierung/maven/README.md
@@ -22,6 +22,12 @@ sudo apt install maven
 sudo rm -f /usr/share/maven/boot/plexus-classworlds-2.x.jar
 ```
 
+## Hello World
+
+```bash
+mvn -version
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/programmierung/nodejs/README.md
+++ b/factsheets/programmierung/nodejs/README.md
@@ -19,6 +19,12 @@ Node.js ist eine JavaScript-Laufzeitumgebung, die auf der Chrome V8 JavaScript-E
 sudo apt install nodejs npm
 ```
 
+## Hello World
+
+```javascript
+console.log("Hello World");
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/programmierung/openocd/README.md
+++ b/factsheets/programmierung/openocd/README.md
@@ -22,6 +22,12 @@ von Hardware-Adaptern und Zielarchitekturen.
 sudo apt install openocd
 ```
 
+## Hello World
+
+```bash
+openocd --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/programmierung/pawn-compiler/README.md
+++ b/factsheets/programmierung/pawn-compiler/README.md
@@ -22,6 +22,14 @@ Skripting.
 
 Vom GitHub-Repository laden.
 
+## Hello World
+
+```pawn
+main() {
+    print("Hello World");
+}
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/programmierung/pillow/README.md
+++ b/factsheets/programmierung/pillow/README.md
@@ -23,6 +23,14 @@ Generierung von Visualisierungen.
 pip install Pillow
 ```
 
+## Hello World
+
+```python
+from PIL import Image
+img = Image.new('RGB', (100, 100), color='red')
+img.save('hello.png')
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/programmierung/platformio-core/README.md
+++ b/factsheets/programmierung/platformio-core/README.md
@@ -24,6 +24,12 @@ und zu kompilieren.
 pip install platformio
 ```
 
+## Hello World
+
+```bash
+pio --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/graphqurl/README.md
+++ b/factsheets/schnittstellen/graphqurl/README.md
@@ -20,6 +20,12 @@ graphqurl (gq) ist ein Kommandozeilenwerkzeug und eine JavaScript-Bibliothek fü
 sudo npm install -g graphqurl
 ```
 
+## Hello World
+
+```bash
+gq https://countries.trevorblades.com/ --query "{ countries { name } }"
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/grpcurl/README.md
+++ b/factsheets/schnittstellen/grpcurl/README.md
@@ -23,6 +23,12 @@ sudo mv grpcurl /usr/local/bin/
 rm grpcurl.tar.gz
 ```
 
+## Hello World
+
+```bash
+grpcurl -plaintext localhost:50051 list
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/openapi-generator/README.md
+++ b/factsheets/schnittstellen/openapi-generator/README.md
@@ -19,6 +19,12 @@ Das Tool ermöglicht die Generierung von API-Clients, Server-Stubs, Dokumentatio
 npm install @openapitools/openapi-generator-cli
 ```
 
+## Hello World
+
+```bash
+openapi-generator-cli version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/rasqal/README.md
+++ b/factsheets/schnittstellen/rasqal/README.md
@@ -20,6 +20,12 @@ Rasqal ist eine C-Bibliothek, die das Parsen und Ausführen von SPARQL-Abfragen 
 sudo apt install rasqal-utils
 ```
 
+## Hello World
+
+```bash
+roqet -q -e "SELECT * WHERE { ?s ?p ?o } LIMIT 1"
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/sparkql/README.md
+++ b/factsheets/schnittstellen/sparkql/README.md
@@ -20,6 +20,19 @@ sparkql ist ein NPM-Paket zur Erstellung von SPARQL-Abfragen mit einer flüssige
 npm install sparkql
 ```
 
+## Hello World
+
+```javascript
+const { select } = require('sparkql');
+
+const query = select('*')
+  .from('<http://dbpedia.org>')
+  .where('?s', '?p', '?o')
+  .limit(1)
+  .build();
+console.log(query);
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/sparqlwrapper/README.md
+++ b/factsheets/schnittstellen/sparqlwrapper/README.md
@@ -20,6 +20,17 @@ SPARQLWrapper ist eine Python-Bibliothek, die als Wrapper um einen SPARQL-Endpun
 sudo apt install python3-sparqlwrapper
 ```
 
+## Hello World
+
+```python
+from SPARQLWrapper import SPARQLWrapper
+
+sparql = SPARQLWrapper("http://dbpedia.org/sparql")
+sparql.setQuery("SELECT * WHERE { ?s ?p ?o } LIMIT 1")
+results = sparql.query().convert()
+print(results)
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/xmllint/README.md
+++ b/factsheets/schnittstellen/xmllint/README.md
@@ -20,6 +20,12 @@ xmllint ist ein Werkzeug aus dem libxml2-Paket zur Validierung, Formatierung und
 sudo apt install libxml2-utils
 ```
 
+## Hello World
+
+```bash
+xmllint --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/xmlstarlet/README.md
+++ b/factsheets/schnittstellen/xmlstarlet/README.md
@@ -20,6 +20,12 @@ XMLStarlet ist ein Toolkit zur XML-Verarbeitung von der Kommandozeile (Validieru
 sudo apt install xmlstarlet
 ```
 
+## Hello World
+
+```bash
+xmlstarlet --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/xsltproc/README.md
+++ b/factsheets/schnittstellen/xsltproc/README.md
@@ -20,6 +20,12 @@ xsltproc ist ein Kommandozeilen-Werkzeug zur Anwendung von XSLT-Stylesheets auf 
 sudo apt install xsltproc
 ```
 
+## Hello World
+
+```bash
+xsltproc --version
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/schnittstellen/zeep/README.md
+++ b/factsheets/schnittstellen/zeep/README.md
@@ -20,6 +20,13 @@ Zeep ist eine moderne SOAP-Client-Bibliothek für Python, die WSDL-Dateien parst
 sudo apt install python3-zeep
 ```
 
+## Hello World
+
+```python
+import zeep
+client = zeep.Client(wsdl='http://www.soapclient.com/xml/soapresponder.wsdl')
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/template-engines/blade/README.md
+++ b/factsheets/template-engines/blade/README.md
@@ -19,6 +19,12 @@ Blade ist die native Template-Engine des populären Laravel-Frameworks. Sie komp
 composer require jenssegers/blade
 ```
 
+## Hello World
+
+```blade
+Hello, {{ $name }}!
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/template-engines/ejs/README.md
+++ b/factsheets/template-engines/ejs/README.md
@@ -19,6 +19,12 @@ Sehr populär im Express.js-Umfeld. Verwendet eine einfache <% %> Syntax, bei de
 sudo apt install -y node-ejs
 ```
 
+## Hello World
+
+```ejs
+<%= 'Hello World' %>
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/template-engines/erb/README.md
+++ b/factsheets/template-engines/erb/README.md
@@ -19,6 +19,12 @@ Die Standard-Engine in Ruby on Rails. Erlaubt das direkte Einbetten von Ruby-Cod
 sudo apt install -y ruby
 ```
 
+## Hello World
+
+```erb
+<%= "Hello World" %>
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/template-engines/handlebars/README.md
+++ b/factsheets/template-engines/handlebars/README.md
@@ -25,6 +25,12 @@ npm install -g handlebars
 handlebars --version
 ```
 
+## Hello World
+
+```handlebars
+{{title}}
+```
+
 ## Beispiele
 
 Im Ordner `examples/` befinden sich verschiedene Handlebars-Templates und zugehörige Datendateien:

--- a/factsheets/template-engines/jinja2/README.md
+++ b/factsheets/template-engines/jinja2/README.md
@@ -25,6 +25,12 @@ pip install Jinja2
 python3 -c "import jinja2; print(jinja2.__version__)"
 ```
 
+## Hello World
+
+```jinja2
+Hello {{ name }}!
+```
+
 ## Beispiele
 
 Im Ordner `examples/` befinden sich verschiedene Jinja2-Templates:

--- a/factsheets/template-engines/liquid/README.md
+++ b/factsheets/template-engines/liquid/README.md
@@ -19,6 +19,12 @@ Ursprünglich von Shopify für E-Commerce-Templates entwickelt. Heute ist es der
 sudo apt install -y ruby-liquid
 ```
 
+## Hello World
+
+```liquid
+{{ "Hello World" | upcase }}
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/template-engines/mustache/README.md
+++ b/factsheets/template-engines/mustache/README.md
@@ -25,6 +25,12 @@ sudo apt install -y node-mustache
 mustache.js --version
 ```
 
+## Hello World
+
+```mustache
+{{name}}
+```
+
 ## Beispiele
 
 Im Ordner `examples/` befinden sich verschiedene Mustache-Templates und zugehörige Datendateien:

--- a/factsheets/template-engines/pug/README.md
+++ b/factsheets/template-engines/pug/README.md
@@ -19,6 +19,12 @@ Setzt auf eine stark abstrahierte, einrückungsbasierte Syntax komplett ohne sch
 npm install -g pug-cli
 ```
 
+## Hello World
+
+```pug
+p Hello World
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/template-engines/razor/README.md
+++ b/factsheets/template-engines/razor/README.md
@@ -19,6 +19,12 @@ Microsofts Standard-Engine für ASP.NET Core MVC und Blazor. Sie besticht durch 
 sudo apt install -y dotnet-sdk-8.0
 ```
 
+## Hello World
+
+```razor
+@("Hello World")
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/template-engines/thymeleaf/README.md
+++ b/factsheets/template-engines/thymeleaf/README.md
@@ -20,6 +20,12 @@ Der De-facto-Standard für moderne Spring-Boot-Anwendungen. Die Besonderheit: Th
 sudo apt install -y maven
 ```
 
+## Hello World
+
+```html
+<p th:text="'Hello World'"></p>
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/template-engines/twig/README.md
+++ b/factsheets/template-engines/twig/README.md
@@ -19,6 +19,12 @@ Twig ist die Standard-Engine des Symfony-Frameworks. Sie wurde stark von Jinja2 
 sudo apt install -y php-twig
 ```
 
+## Hello World
+
+```twig
+{{ "Hello World" }}
+```
+
 ## Validierung
 
 ```bash

--- a/factsheets/testing/hurl/README.md
+++ b/factsheets/testing/hurl/README.md
@@ -23,6 +23,13 @@ autonom zu validieren.
 sudo add-apt-repository ppa:lepapareil/hurl; sudo apt update; sudo apt install hurl
 ```
 
+## Hello World
+
+```hurl
+GET http://localhost:3000
+HTTP 200
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/testing/playwright/README.md
+++ b/factsheets/testing/playwright/README.md
@@ -24,6 +24,20 @@ verifizieren.
 npm install playwright
 ```
 
+## Hello World
+
+```javascript
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('https://playwright.dev/');
+  console.log(await page.title());
+  await browser.close();
+})();
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/testing/prism/README.md
+++ b/factsheets/testing/prism/README.md
@@ -22,6 +22,12 @@ generieren.
 npm install @stoplight/prism-cli
 ```
 
+## Hello World
+
+```bash
+prism mock api.yaml
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/testing/schemathesis/README.md
+++ b/factsheets/testing/schemathesis/README.md
@@ -19,6 +19,12 @@ Schemathesis nutzt die OpenAPI-Spezifikation einer API, um automatisch Testfäll
 pip install schemathesis
 ```
 
+## Hello World
+
+```bash
+schemathesis run http://localhost:8080/openapi.json
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/testing/spectral/README.md
+++ b/factsheets/testing/spectral/README.md
@@ -21,6 +21,12 @@ ist hochgradig erweiterbar durch eigene Regelsätze.
 npm install @stoplight/spectral-cli
 ```
 
+## Hello World
+
+```bash
+spectral lint openapi.yaml
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/factsheets/testing/step-ci/README.md
+++ b/factsheets/testing/step-ci/README.md
@@ -19,6 +19,12 @@ Step CI ist ein deklaratives Framework zum Testen und Überwachen von REST-, Gra
 npm install -g stepci
 ```
 
+## Hello World
+
+```bash
+step-ci run workflow.yml
+```
+
 ## Beispieldaten
 
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:

--- a/scripts/add_hello_world.py
+++ b/scripts/add_hello_world.py
@@ -1,0 +1,167 @@
+import os
+import re
+
+# Mapping of tool path to Hello World snippet
+# Format: { 'factsheets/category/tool': ('language', 'snippet') }
+SNIPPETS = {
+    'factsheets/animation/blender': ('python', 'import bpy\nbpy.ops.mesh.primitive_cube_add()'),
+    'factsheets/animation/ffmpeg': ('bash', 'ffmpeg -version'),
+    'factsheets/animation/imagemagick': ('bash', "convert -size 100x100 xc:white -draw \"text 10,50 'Hello World'\" hello.png"),
+    'factsheets/animation/krita': ('bash', 'krita --version'),
+    'factsheets/animation/manim': ('python', 'from manim import *\n\nclass HelloWorld(Scene):\n    def construct(self):\n        self.add(Text("Hello World"))'),
+    'factsheets/animation/pencil2d': ('bash', 'pencil2d --version'),
+    'factsheets/animation/synfig-studio': ('bash', 'synfig --version'),
+    'factsheets/app-entwicklung/flutter': ('dart', "import 'package:flutter/material.dart';\n\nvoid main() => runApp(Text('Hello World'));"),
+    'factsheets/app-entwicklung/react': ('jsx', "import React from 'react';\nimport ReactDOM from 'react-dom';\n\nReactDOM.render(<h1>Hello, world!</h1>, document.getElementById('root'));"),
+    'factsheets/app-entwicklung/react-native': ('jsx', "import React from 'react';\nimport { Text } from 'react-native';\n\nexport default () => <Text>Hello World</Text>;"),
+    'factsheets/app-entwicklung/spring-boot': ('java', "@RestController\nclass Hello {\n    @GetMapping(\"/\")\n    String hi() { return \"Hello World\"; }\n}"),
+    'factsheets/bioinformatik/biopython': ('python', 'from Bio.Seq import Seq\nprint(Seq("AGT").reverse_complement())'),
+    'factsheets/bioinformatik/bkchem': ('bash', 'bkchem --version'),
+    'factsheets/bioinformatik/chemfig': ('latex', '\\chemfig{H-O-H}'),
+    'factsheets/bioinformatik/jmol': ('bash', 'jmol -n -g 100x100 -J "load $caffeine; write image hello.png"'),
+    'factsheets/bioinformatik/pymol': ('python', 'import pymol\npymol.finish_launching()'),
+    'factsheets/bioinformatik/rdkit': ('python', "from rdkit import Chem\nprint(Chem.MolToSmiles(Chem.MolFromSmiles('C')))"),
+    'factsheets/bioinformatik/seqkit': ('bash', 'seqkit version'),
+    'factsheets/cad-3d/freecad': ('python', 'import FreeCAD\nFreeCAD.Console.PrintMessage("Hello World\\n")'),
+    'factsheets/cad-3d/ldview': ('bash', 'ldview --version'),
+    'factsheets/cad-3d/mcp-freecad': ('bash', 'npx mcp-freecad'),
+    'factsheets/cad-3d/meshlab': ('bash', 'meshlabserver -version'),
+    'factsheets/cad-3d/openscad': ('openscad', 'cube([10,10,10]);'),
+    'factsheets/datenbanken/mariadb': ('sql', "SELECT 'Hello World';"),
+    'factsheets/datenbanken/mssql': ('sql', "SELECT 'Hello World';"),
+    'factsheets/datenbanken/oracle': ('sql', "SELECT 'Hello World' FROM dual;"),
+    'factsheets/datenbanken/postgresql': ('sql', "SELECT 'Hello World';"),
+    'factsheets/dokumentation/apache-fop': ('xml', '<fo:block>Hello World</fo:block>'),
+    'factsheets/dokumentation/img2pdf': ('bash', 'img2pdf -o out.pdf in.jpg'),
+    'factsheets/dokumentation/plantuml': ('plantuml', '@startuml\nAlice -> Bob: Hello World\n@enduml'),
+    'factsheets/dokumentation/redocly-cli': ('bash', 'redocly lint openapi.yaml'),
+    'factsheets/dokumentation/wavedrom': ('json', '{ "signal": [ { "name": "clk", "wave": "p....." } ] }'),
+    'factsheets/eda/circuitikz': ('latex', '\\begin{circuitikz}\n\\draw (0,0) to[R=1<\\ohm>] (2,0);\n\\end{circuitikz}'),
+    'factsheets/eda/cocotb': ('python', '@cocotb.test()\nasync def test(dut):\n    dut._log.info("Hello World")'),
+    'factsheets/eda/kibot': ('bash', 'kibot --version'),
+    'factsheets/eda/kicad-10-0': ('bash', 'kicad --version'),
+    'factsheets/eda/openfpgaloader': ('bash', 'openFPGALoader --version'),
+    'factsheets/eda/skidl': ('python', 'from skidl import *\nr1 = Part("Device", "R")\nprint("Hello SKiDL")'),
+    'factsheets/eda/yosys': ('bash', 'yosys -p "help"'),
+    'factsheets/firmware-analyse/binwalk': ('bash', 'binwalk firmware.bin'),
+    'factsheets/firmware-analyse/cve-bin-tool': ('bash', 'cve-bin-tool .'),
+    'factsheets/firmware-analyse/emba': ('bash', './emba -h'),
+    'factsheets/firmware-analyse/ghidra': ('bash', './analyzeHeadless . temp -preScript HelloWorldScript.java'),
+    'factsheets/firmware-analyse/gnu-binutils': ('bash', 'objdump -h file.o'),
+    'factsheets/firmware-analyse/hexdump': ('bash', 'echo "Hello" | hexdump -C'),
+    'factsheets/firmware-analyse/panda': ('bash', 'panda-system-x86_64 --version'),
+    'factsheets/firmware-analyse/radare2': ('bash', 'r2 -c "pd 10" /bin/ls'),
+    'factsheets/firmware-analyse/yara': ('yara', 'rule hello { condition: true }'),
+    'factsheets/funktechnik/gnuradio': ('bash', 'gnuradio-config-info --version'),
+    'factsheets/funktechnik/gqrx-sdr': ('bash', 'gqrx --version'),
+    'factsheets/funktechnik/inspectrum': ('bash', 'inspectrum --version'),
+    'factsheets/funktechnik/node-red': ('bash', 'node-red --version'),
+    'factsheets/funktechnik/rtl-sdr': ('bash', 'rtl_test'),
+    'factsheets/funktechnik/urh': ('bash', 'urh --version'),
+    'factsheets/geodaten/josm': ('bash', 'josm --version'),
+    'factsheets/geodaten/osm2pgsql': ('bash', 'osm2pgsql --version'),
+    'factsheets/geodaten/osmium-tool': ('bash', 'osmium --version'),
+    'factsheets/geodaten/osmosis': ('bash', 'osmosis --help'),
+    'factsheets/geodaten/postgis': ('sql', 'SELECT PostGIS_Full_Version();'),
+    'factsheets/hardware-simulation/renode': ('bash', 'renode -e "echo \'Hello World\'; quit"'),
+    'factsheets/infrastruktur/aws-cli': ('bash', 'aws --version'),
+    'factsheets/infrastruktur/aws-mcp-server': ('bash', 'npx @awslabs/aws-api-mcp-server'),
+    'factsheets/infrastruktur/azure-cli': ('bash', 'az --version'),
+    'factsheets/infrastruktur/azure-mcp-server': ('bash', 'npx @microsoft/azmcp'),
+    'factsheets/infrastruktur/docker': ('bash', 'docker run hello-world'),
+    'factsheets/infrastruktur/docker-compose': ('bash', 'docker-compose --version'),
+    'factsheets/infrastruktur/google-cloud-run-mcp': ('bash', 'npx @google-cloud/cloud-run-mcp'),
+    'factsheets/infrastruktur/google-cloud-sdk': ('bash', 'gcloud --version'),
+    'factsheets/infrastruktur/kubernetes': ('bash', 'kubectl version'),
+    'factsheets/infrastruktur/vast-ai-sdk': ('bash', 'vastai --version'),
+    'factsheets/infrastruktur/xvfb': ('bash', 'Xvfb :99 &'),
+    'factsheets/ki-inferenz/ollama': ('bash', 'ollama run llama3 "Hello World"'),
+    'factsheets/ki-inferenz/vllm': ('bash', 'python3 -m vllm.entrypoints.openai.api_server'),
+    'factsheets/programmierung/ant': ('xml', '<project><target name="hello"><echo>Hello World</echo></target></project>'),
+    'factsheets/programmierung/arduino-cli': ('bash', 'arduino-cli version'),
+    'factsheets/programmierung/arm-gdb': ('bash', 'arm-none-eabi-gdb --version'),
+    'factsheets/programmierung/blockly': ('javascript', "Blockly.inject('blocklyDiv', {toolbox: toolbox});"),
+    'factsheets/programmierung/composer': ('bash', 'composer --version'),
+    'factsheets/programmierung/gnu-toolchain-for-arm': ('bash', 'arm-none-eabi-gcc --version'),
+    'factsheets/programmierung/java': ('java', 'public class Main {\n    public static void main(String[] args) {\n        System.out.println("Hello World");\n    }\n}'),
+    'factsheets/programmierung/maven': ('bash', 'mvn -version'),
+    'factsheets/programmierung/nodejs': ('javascript', 'console.log("Hello World");'),
+    'factsheets/programmierung/openocd': ('bash', 'openocd --version'),
+    'factsheets/programmierung/pawn-compiler': ('pawn', 'main() {\n    print("Hello World");\n}'),
+    'factsheets/programmierung/pillow': ('python', "from PIL import Image\nimg = Image.new('RGB', (100, 100), color='red')\nimg.save('hello.png')"),
+    'factsheets/programmierung/platformio-core': ('bash', 'pio --version'),
+    'factsheets/schnittstellen/graphqurl': ('bash', 'gq https://countries.trevorblades.com/ --query "{ countries { name } }"'),
+    'factsheets/schnittstellen/grpcurl': ('bash', 'grpcurl -plaintext localhost:50051 list'),
+    'factsheets/schnittstellen/openapi-generator': ('bash', 'openapi-generator-cli version'),
+    'factsheets/schnittstellen/rasqal': ('bash', 'roqet -q -e "SELECT * WHERE { ?s ?p ?o } LIMIT 1"'),
+    'factsheets/schnittstellen/sparkql': ('javascript', "const { select } = require('sparkql');\n\nconst query = select('*')\n  .from('<http://dbpedia.org>')\n  .where('?s', '?p', '?o')\n  .limit(1)\n  .build();\nconsole.log(query);"),
+    'factsheets/schnittstellen/sparqlwrapper': ('python', 'from SPARQLWrapper import SPARQLWrapper\n\nsparql = SPARQLWrapper("http://dbpedia.org/sparql")\nsparql.setQuery("SELECT * WHERE { ?s ?p ?o } LIMIT 1")\nresults = sparql.query().convert()\nprint(results)'),
+    'factsheets/schnittstellen/xmllint': ('bash', 'xmllint --version'),
+    'factsheets/schnittstellen/xmlstarlet': ('bash', 'xmlstarlet --version'),
+    'factsheets/schnittstellen/xsltproc': ('bash', 'xsltproc --version'),
+    'factsheets/schnittstellen/zeep': ('python', "import zeep\nclient = zeep.Client(wsdl='http://www.soapclient.com/xml/soapresponder.wsdl')"),
+    'factsheets/template-engines/blade': ('blade', 'Hello, {{ $name }}!'),
+    'factsheets/template-engines/ejs': ('ejs', "<%= 'Hello World' %>"),
+    'factsheets/template-engines/erb': ('erb', '<%= "Hello World" %>'),
+    'factsheets/template-engines/handlebars': ('handlebars', '{{title}}'),
+    'factsheets/template-engines/jinja2': ('jinja2', 'Hello {{ name }}!'),
+    'factsheets/template-engines/liquid': ('liquid', '{{ "Hello World" | upcase }}'),
+    'factsheets/template-engines/mustache': ('mustache', '{{name}}'),
+    'factsheets/template-engines/pug': ('pug', 'p Hello World'),
+    'factsheets/template-engines/razor': ('razor', '@("Hello World")'),
+    'factsheets/template-engines/thymeleaf': ('html', '<p th:text="\'Hello World\'"></p>'),
+    'factsheets/template-engines/twig': ('twig', '{{ "Hello World" }}'),
+    'factsheets/testing/hurl': ('hurl', 'GET http://localhost:3000\nHTTP 200'),
+    'factsheets/testing/playwright': ('javascript', "const { chromium } = require('playwright');\n\n(async () => {\n  const browser = await chromium.launch();\n  const page = await browser.newPage();\n  await page.goto('https://playwright.dev/');\n  console.log(await page.title());\n  await browser.close();\n})();"),
+    'factsheets/testing/prism': ('bash', 'prism mock api.yaml'),
+    'factsheets/testing/schemathesis': ('bash', 'schemathesis run http://localhost:8080/openapi.json'),
+    'factsheets/testing/spectral': ('bash', 'spectral lint openapi.yaml'),
+    'factsheets/testing/step-ci': ('bash', 'step-ci run workflow.yml'),
+}
+
+def add_hello_world_snippet(tool_path, lang, snippet):
+    readme_path = os.path.join(tool_path, 'README.md')
+    if not os.path.exists(readme_path):
+        print(f"README.md not found in {tool_path}")
+        return
+
+    with open(readme_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    if '## Hello World' in content:
+        print(f"## Hello World already exists in {readme_path}")
+        return
+
+    hello_world_section = f"## Hello World\n\n```{lang}\n{snippet}\n```\n\n"
+
+    # Try to find a good place to insert:
+    # 1. Before "Beispiel" or "Beispieldaten"
+    # 2. Before "Validierung"
+    # 3. At the end
+
+    insertion_points = [r'## Beispiele', r'## Beispieldaten', r'## Validierung']
+
+    inserted = False
+    for point in insertion_points:
+        match = re.search(f'^{point}', content, re.MULTILINE)
+        if match:
+            new_content = content[:match.start()] + hello_world_section + content[match.start():]
+            with open(readme_path, 'w', encoding='utf-8') as f:
+                f.write(new_content)
+            inserted = True
+            print(f"Inserted ## Hello World in {readme_path} before {point}")
+            break
+
+    if not inserted:
+        with open(readme_path, 'a', encoding='utf-8') as f:
+            if not content.endswith('\n'):
+                f.write('\n\n')
+            f.write(hello_world_section)
+        print(f"Appended ## Hello World to {readme_path}")
+
+def main():
+    for tool_path, (lang, snippet) in SNIPPETS.items():
+        add_hello_world_snippet(tool_path, lang, snippet)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change introduces a minimal functional example to each of the 113+ tool factsheets in the repository. The examples range from simple CLI version checks to actual code snippets (Python, Java, SQL, etc.) and templates (Jinja2, Liquid, Blade, etc.). An automation script was used to ensure consistency across the large number of files. Maintenance scripts were also run to update central registries and MkDocs configuration.

Fixes #203

---
*PR created automatically by Jules for task [17322293100498839045](https://jules.google.com/task/17322293100498839045) started by @chatelao*