### PR TITLE
Supplement missing examples for multiple tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ factsheets/firmware-analyse/emba/emba/
 factsheets/firmware-analyse/ghidra/ghidra_12.0.4_PUBLIC/
 factsheets/firmware-analyse/ghidra/*.zip
 log/*.log
+docs/
+site/

--- a/FACTSHEET_ROADMAP.md
+++ b/FACTSHEET_ROADMAP.md
@@ -7,7 +7,7 @@ Diese Roadmap dokumentiert den aktuellen Stand der Werkzeug-Factsheets und defin
 Nach einer automatisierten Analyse aller Factsheets wurden folgende Defizite identifiziert:
 
 - **Gesamtanzahl Factsheets:** 114 (geschätzt)
-- **Factsheets mit Verbesserungsbedarf:** 58
+- **Factsheets mit Verbesserungsbedarf:** 47
 - **Hauptprobleme:**
     - Platzhalter-Beschreibungen (Zweck-Sektion unvollständig)
     - Fehlende oder unzureichende Beispieldaten (weniger als 5 Beispiele)
@@ -71,23 +71,12 @@ Nach einer automatisierten Analyse aller Factsheets wurden folgende Defizite ide
 | Infrastruktur | vast-ai-sdk | Few examples (4) |
 | Infrastruktur | xvfb | Few examples (3) |
 | Ki-inferenz | vllm | Few examples (4) |
-| Programmierung | ant | No examples |
-| Programmierung | composer | No examples |
-| Programmierung | java | No examples |
-| Programmierung | maven | No examples |
-| Programmierung | nodejs | No examples |
 | Schnittstellen | graphqurl | Few examples (2) |
 | Schnittstellen | grpcurl | Few examples (2) |
 | Schnittstellen | openapi-generator | Few examples (4) |
 | Schnittstellen | rasqal | Few examples (2) |
 | Schnittstellen | sparkql | Few examples (1) |
 | Schnittstellen | sparqlwrapper | Few examples (1) |
-| Template-engines | blade | No examples |
-| Template-engines | erb | No examples |
-| Template-engines | liquid | No examples |
-| Template-engines | pug | No examples |
-| Template-engines | razor | No examples |
-| Template-engines | thymeleaf | No examples |
 | Testing | prism | Few examples (2) |
 | Testing | schemathesis | Installation issue: Log-Fehler: Fehlgeschlagen |
 | Testing | spectral | Few examples (4), Installation issue: Verifizierungsdatei fehlt (.hash.sha256) |

--- a/factsheets/programmierung/ant/README.md
+++ b/factsheets/programmierung/ant/README.md
@@ -31,3 +31,13 @@ sudo apt install ant
 ```bash
 ant -version
 ```
+
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Ant-Build-Dateien (`.xml`):
+
+1.  `build-minimal.xml`: Ein minimales Ant-Projekt mit einem "Hello World" Target.
+2.  `build-java.xml`: Ein strukturierter Build-Prozess für Java (Clean, Compile, Jar).
+3.  `build-properties.xml`: Verwendung von Properties und Laden von Property-Dateien.
+4.  `build-conditions.xml`: Einsatz von Bedingungen zur Steuerung des Build-Flusses.
+5.  `build-files.xml`: Dateioperationen wie Kopieren, Filtern und Archivieren.

--- a/factsheets/programmierung/ant/examples/build-conditions.xml
+++ b/factsheets/programmierung/ant/examples/build-conditions.xml
@@ -1,0 +1,20 @@
+<project name="ConditionDemo" default="check-os">
+  <target name="check-os">
+    <condition property="isWindows">
+      <os family="windows"/>
+    </condition>
+    <condition property="isUnix">
+      <os family="unix"/>
+    </condition>
+    <antcall target="print-windows"/>
+    <antcall target="print-unix"/>
+  </target>
+
+  <target name="print-windows" if="isWindows">
+    <echo message="Running on Windows"/>
+  </target>
+
+  <target name="print-unix" if="isUnix">
+    <echo message="Running on Unix"/>
+  </target>
+</project>

--- a/factsheets/programmierung/ant/examples/build-files.xml
+++ b/factsheets/programmierung/ant/examples/build-files.xml
@@ -1,0 +1,11 @@
+<project name="FileOps" default="copy-files">
+  <target name="copy-files">
+    <copy todir="dest">
+      <fileset dir="src">
+        <include name="**/*.java"/>
+        <exclude name="**/Test*.java"/>
+      </fileset>
+    </copy>
+    <zip destfile="backup.zip" basedir="dest"/>
+  </target>
+</project>

--- a/factsheets/programmierung/ant/examples/build-java.xml
+++ b/factsheets/programmierung/ant/examples/build-java.xml
@@ -1,0 +1,20 @@
+<project name="JavaBuild" default="compile" basedir=".">
+  <property name="src.dir" value="src"/>
+  <property name="build.dir" value="build"/>
+  <property name="classes.dir" value="${build.dir}/classes"/>
+  <property name="jar.dir" value="${build.dir}/jar"/>
+
+  <target name="clean">
+    <delete dir="${build.dir}"/>
+  </target>
+
+  <target name="compile">
+    <mkdir dir="${classes.dir}"/>
+    <javac srcdir="${src.dir}" destdir="${classes.dir}"/>
+  </target>
+
+  <target name="jar" depends="compile">
+    <mkdir dir="${jar.dir}"/>
+    <jar destfile="${jar.dir}/${ant.project.name}.jar" basedir="${classes.dir}"/>
+  </target>
+</project>

--- a/factsheets/programmierung/ant/examples/build-minimal.xml
+++ b/factsheets/programmierung/ant/examples/build-minimal.xml
@@ -1,0 +1,5 @@
+<project name="HelloWorld" default="hello" basedir=".">
+  <target name="hello">
+    <echo>Hello, Ant!</echo>
+  </target>
+</project>

--- a/factsheets/programmierung/ant/examples/build-properties.xml
+++ b/factsheets/programmierung/ant/examples/build-properties.xml
@@ -1,0 +1,8 @@
+<project name="PropertiesDemo" default="print">
+  <property file="build.properties"/>
+  <property name="my.prop" value="Default Value"/>
+
+  <target name="print">
+    <echo message="Property value: ${my.prop}"/>
+  </target>
+</project>

--- a/factsheets/programmierung/composer/README.md
+++ b/factsheets/programmierung/composer/README.md
@@ -25,6 +25,16 @@ sudo apt install composer
 composer --version
 ```
 
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Composer-Konfigurationsbeispiele (`.json`):
+
+1.  `minimal-composer.json`: Eine grundlegende `composer.json` mit PHP-Version und einer Abhängigkeit.
+2.  `autoload-config.json`: Konfiguration von PSR-4 Autoloading für Source- und Test-Verzeichnisse.
+3.  `scripts-example.json`: Definition von benutzerdefinierten Skripten und Hooks.
+4.  `custom-repository.json`: Einbinden von privaten VCS-Repositories.
+5.  `config-options.json`: Verschiedene Konfigurationsoptionen zur Optimierung und Sicherheit.
+
 ## Validierung
 
 ```bash

--- a/factsheets/programmierung/composer/examples/autoload-config.json
+++ b/factsheets/programmierung/composer/examples/autoload-config.json
@@ -1,0 +1,12 @@
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Tests\\": "tests/"
+        }
+    }
+}

--- a/factsheets/programmierung/composer/examples/config-options.json
+++ b/factsheets/programmierung/composer/examples/config-options.json
@@ -1,0 +1,10 @@
+{
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    }
+}

--- a/factsheets/programmierung/composer/examples/custom-repository.json
+++ b/factsheets/programmierung/composer/examples/custom-repository.json
@@ -1,0 +1,11 @@
+{
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/mycompany/privaterepo"
+        }
+    ],
+    "require": {
+        "mycompany/privaterepo": "dev-main"
+    }
+}

--- a/factsheets/programmierung/composer/examples/minimal-composer.json
+++ b/factsheets/programmierung/composer/examples/minimal-composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "vendor/package",
+    "description": "A minimal composer.json example",
+    "require": {
+        "php": ">=8.1",
+        "monolog/monolog": "3.5.*"
+    }
+}

--- a/factsheets/programmierung/composer/examples/scripts-example.json
+++ b/factsheets/programmierung/composer/examples/scripts-example.json
@@ -1,0 +1,9 @@
+{
+    "scripts": {
+        "post-update-cmd": [
+            "Illuminate\\Foundation\\ComposerScripts::postUpdate"
+        ],
+        "test": "vendor/bin/phpunit",
+        "check-style": "phpcs src tests"
+    }
+}

--- a/factsheets/programmierung/java/README.md
+++ b/factsheets/programmierung/java/README.md
@@ -36,3 +36,13 @@ public class Main {
 java -version
 javac -version
 ```
+
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Java-Beispiele:
+
+1.  `HelloWorld.java`: Ein klassisches "Hello World" Programm mit Argumentverarbeitung.
+2.  `CollectionsDemo.java`: Demonstration von Java Collections (ArrayList, HashMap).
+3.  `StreamApiDemo.java`: Verwendung der Stream API zum Filtern und Transformieren von Daten.
+4.  `FileIODemo.java`: Lesen und Schreiben von Dateien mit Try-with-Resources.
+5.  `ConcurrencyDemo.java`: Verwendung von Thread-Pools und ExecutorService für Nebenläufigkeit.

--- a/factsheets/programmierung/java/examples/CollectionsDemo.java
+++ b/factsheets/programmierung/java/examples/CollectionsDemo.java
@@ -1,0 +1,19 @@
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CollectionsDemo {
+    public static void main(String[] args) {
+        List<String> list = new ArrayList<>();
+        list.add("Apple");
+        list.add("Banana");
+
+        Map<String, Integer> map = new HashMap<>();
+        map.put("One", 1);
+        map.put("Two", 2);
+
+        System.out.println("List: " + list);
+        System.out.println("Map: " + map);
+    }
+}

--- a/factsheets/programmierung/java/examples/ConcurrencyDemo.java
+++ b/factsheets/programmierung/java/examples/ConcurrencyDemo.java
@@ -1,0 +1,17 @@
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class ConcurrencyDemo {
+    public static void main(String[] args) {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        for (int i = 0; i < 5; i++) {
+            int taskId = i;
+            executor.submit(() -> {
+                System.out.println("Task " + taskId + " running on thread " + Thread.currentThread().getName());
+            });
+        }
+
+        executor.shutdown();
+    }
+}

--- a/factsheets/programmierung/java/examples/FileIODemo.java
+++ b/factsheets/programmierung/java/examples/FileIODemo.java
@@ -1,0 +1,23 @@
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class FileIODemo {
+    public static void main(String[] args) {
+        String filename = "test.txt";
+
+        try (FileWriter writer = new FileWriter(filename)) {
+            writer.write("Hello Java IO!");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(filename))) {
+            String line = reader.readLine();
+            System.out.println("Read from file: " + line);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/factsheets/programmierung/java/examples/HelloWorld.java
+++ b/factsheets/programmierung/java/examples/HelloWorld.java
@@ -1,0 +1,14 @@
+import java.util.Scanner;
+
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+
+        if (args.length > 0) {
+            System.out.println("Arguments provided:");
+            for (String arg : args) {
+                System.out.println("- " + arg);
+            }
+        }
+    }
+}

--- a/factsheets/programmierung/java/examples/StreamApiDemo.java
+++ b/factsheets/programmierung/java/examples/StreamApiDemo.java
@@ -1,0 +1,16 @@
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StreamApiDemo {
+    public static void main(String[] args) {
+        List<Integer> numbers = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        List<Integer> evenSquares = numbers.stream()
+                .filter(n -> n % 2 == 0)
+                .map(n -> n * n)
+                .collect(Collectors.toList());
+
+        System.out.println("Even squares: " + evenSquares);
+    }
+}

--- a/factsheets/programmierung/maven/README.md
+++ b/factsheets/programmierung/maven/README.md
@@ -28,6 +28,16 @@ sudo rm -f /usr/share/maven/boot/plexus-classworlds-2.x.jar
 mvn -version
 ```
 
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Maven-Konfigurationsbeispiele:
+
+1.  `minimal-pom.xml`: Eine grundlegende `pom.xml` für ein Java-Projekt.
+2.  `compiler-config.xml`: Konfiguration der Java-Version für den Compiler.
+3.  `shade-plugin-config.xml`: Beispiel für die Konfiguration des Maven Shade Plugins zur Erstellung eines "Fat JARs".
+4.  `dependencies-example.xml`: Beispiel für das Hinzufügen von Abhängigkeiten (z.B. Spring Boot).
+5.  `settings-example.xml`: Beispiel für eine `settings.xml` zur Konfiguration von Repositories und lokalen Pfaden.
+
 ## Validierung
 
 ```bash

--- a/factsheets/programmierung/maven/examples/compiler-config.xml
+++ b/factsheets/programmierung/maven/examples/compiler-config.xml
@@ -1,0 +1,8 @@
+<project ...>
+  ...
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+  </properties>
+  ...
+</project>

--- a/factsheets/programmierung/maven/examples/dependencies-example.xml
+++ b/factsheets/programmierung/maven/examples/dependencies-example.xml
@@ -1,0 +1,9 @@
+<project ...>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/factsheets/programmierung/maven/examples/minimal-pom.xml
+++ b/factsheets/programmierung/maven/examples/minimal-pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>my-app</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/factsheets/programmierung/maven/examples/settings-example.xml
+++ b/factsheets/programmierung/maven/examples/settings-example.xml
@@ -1,0 +1,16 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/path/to/local/repo</localRepository>
+  <profiles>
+    <profile>
+      <id>my-profile</id>
+      <repositories>
+        <repository>
+          <id>internal-repo</id>
+          <url>http://repo.mycompany.com/maven2</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+</settings>

--- a/factsheets/programmierung/maven/examples/shade-plugin-config.xml
+++ b/factsheets/programmierung/maven/examples/shade-plugin-config.xml
@@ -1,0 +1,17 @@
+<project ...>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/factsheets/programmierung/nodejs/README.md
+++ b/factsheets/programmierung/nodejs/README.md
@@ -31,3 +31,13 @@ console.log("Hello World");
 node --version
 npm --version
 ```
+
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Node.js-Beispiele:
+
+1.  `hello.js`: Grundlegende Konsolenausgabe und Prozessinformationen.
+2.  `filesystem.js`: Lesen und Schreiben von Dateien mit dem `fs` Modul.
+3.  `server.js`: Erstellung eines einfachen HTTP-Servers.
+4.  `async_await.js`: Demonstration von asynchroner Programmierung mit Promises und async/await.
+5.  `os_path.js`: Verwendung der eingebauten `os` und `path` Module für Systeminformationen und Pfadmanipulation.

--- a/factsheets/programmierung/nodejs/examples/async_await.js
+++ b/factsheets/programmierung/nodejs/examples/async_await.js
@@ -1,0 +1,11 @@
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function run() {
+  console.log('Waiting 1 second...');
+  await delay(1000);
+  console.log('Done!');
+}
+
+run();

--- a/factsheets/programmierung/nodejs/examples/filesystem.js
+++ b/factsheets/programmierung/nodejs/examples/filesystem.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+
+const content = 'Hello from Node.js File System!';
+fs.writeFile('example.txt', content, err => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+  console.log('File written successfully');
+
+  fs.readFile('example.txt', 'utf8', (err, data) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    console.log('File content:', data);
+  });
+});

--- a/factsheets/programmierung/nodejs/examples/hello.js
+++ b/factsheets/programmierung/nodejs/examples/hello.js
@@ -1,0 +1,3 @@
+console.log("Hello, Node.js!");
+console.log("Arguments:", process.argv.slice(2));
+console.log("Platform:", process.platform);

--- a/factsheets/programmierung/nodejs/examples/os_path.js
+++ b/factsheets/programmierung/nodejs/examples/os_path.js
@@ -1,0 +1,6 @@
+const path = require('path');
+const os = require('os');
+
+console.log('Home Directory:', os.homedir());
+console.log('Total Memory:', (os.totalmem() / 1024 / 1024 / 1024).toFixed(2), 'GB');
+console.log('Joined Path:', path.join(__dirname, 'examples', 'hello.js'));

--- a/factsheets/programmierung/nodejs/examples/server.js
+++ b/factsheets/programmierung/nodejs/examples/server.js
@@ -1,0 +1,14 @@
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('Hello World from Node.js Server\n');
+});
+
+const PORT = 3000;
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Server running at http://127.0.0.1:${PORT}/`);
+  // Automatically close server after 2 seconds for this example
+  setTimeout(() => server.close(), 2000);
+});

--- a/factsheets/template-engines/blade/README.md
+++ b/factsheets/template-engines/blade/README.md
@@ -30,3 +30,13 @@ Hello, {{ $name }}!
 ```bash
 ls vendor/jenssegers/blade/src/Blade.php
 ```
+
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Blade-Templates:
+
+1.  `basic.blade.php`: Grundlegende Variablenersetzung und unescaped HTML.
+2.  `loop.blade.php`: Verwendung von `@foreach` und `@forelse` Schleifen.
+3.  `conditional.blade.php`: Bedingte Anweisungen mit `@if`, `@auth` und `@guest`.
+4.  `layout.blade.php`: Definition eines Master-Layouts mit `@yield` und `@section`.
+5.  `child.blade.php`: Erweitern eines Layouts mit `@extends` und Überschreiben von Sektionen.

--- a/factsheets/template-engines/blade/examples/basic.blade.php
+++ b/factsheets/template-engines/blade/examples/basic.blade.php
@@ -1,0 +1,3 @@
+<h1>Hello, {{ $name }}</h1>
+<p>The current time is {{ time() }}.</p>
+<p>Unescaped: {!! $rawHtml !!}</p>

--- a/factsheets/template-engines/blade/examples/child.blade.php
+++ b/factsheets/template-engines/blade/examples/child.blade.php
@@ -1,0 +1,13 @@
+@extends('layout')
+
+@section('title', 'Page Title')
+
+@section('sidebar')
+    @parent
+
+    <p>This is appended to the master sidebar.</p>
+@endsection
+
+@section('content')
+    <p>This is my body content.</p>
+@endsection

--- a/factsheets/template-engines/blade/examples/conditional.blade.php
+++ b/factsheets/template-engines/blade/examples/conditional.blade.php
@@ -1,0 +1,15 @@
+@if (count($records) === 1)
+    I have one record!
+@elseif (count($records) > 1)
+    I have multiple records!
+@else
+    I don't have any records!
+@endif
+
+@auth
+    // The user is authenticated...
+@endauth
+
+@guest
+    // The user is not authenticated...
+@endguest

--- a/factsheets/template-engines/blade/examples/layout.blade.php
+++ b/factsheets/template-engines/blade/examples/layout.blade.php
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <title>App Name - @yield('title')</title>
+    </head>
+    <body>
+        @section('sidebar')
+            This is the master sidebar.
+        @show
+
+        <div class="container">
+            @yield('content')
+        </div>
+    </body>
+</html>

--- a/factsheets/template-engines/blade/examples/loop.blade.php
+++ b/factsheets/template-engines/blade/examples/loop.blade.php
@@ -1,0 +1,11 @@
+<ul>
+    @foreach ($users as $user)
+        <li>{{ $user->name }} ({{ $user->email }})</li>
+    @endforeach
+</ul>
+
+@forelse ($items as $item)
+    <li>{{ $item }}</li>
+@empty
+    <p>No items found.</p>
+@endforelse

--- a/factsheets/template-engines/erb/README.md
+++ b/factsheets/template-engines/erb/README.md
@@ -30,3 +30,13 @@ sudo apt install -y ruby
 ```bash
 erb -v
 ```
+
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene ERB-Templates:
+
+1.  `basic.erb`: Grundlegende Variablenersetzung und Ruby-Code-Ausführung.
+2.  `loop.erb`: Iteration über eine Liste von Objekten.
+3.  `conditional.erb`: Bedingte Logik mit `if` und `unless`.
+4.  `newline_control.erb`: Steuerung von Zeilenumbrüchen mit der `-` Syntax.
+5.  `partial.erb`: Konzept von Partials und sicherer HTML-Ausgabe.

--- a/factsheets/template-engines/erb/examples/basic.erb
+++ b/factsheets/template-engines/erb/examples/basic.erb
@@ -1,0 +1,3 @@
+Hello, <%= name %>!
+The time is now <%= Time.now %>
+<%# This is a comment %>

--- a/factsheets/template-engines/erb/examples/conditional.erb
+++ b/factsheets/template-engines/erb/examples/conditional.erb
@@ -1,0 +1,9 @@
+<% if @user.admin? %>
+  <h1>Admin Dashboard</h1>
+<% else %>
+  <h1>User Profile</h1>
+<% end %>
+
+<% unless @items.empty? %>
+  <p>You have items!</p>
+<% end %>

--- a/factsheets/template-engines/erb/examples/loop.erb
+++ b/factsheets/template-engines/erb/examples/loop.erb
@@ -1,0 +1,5 @@
+<ul>
+<% @users.each do |user| %>
+  <li><%= user.name %> (<%= user.email %>)</li>
+<% end %>
+</ul>

--- a/factsheets/template-engines/erb/examples/newline_control.erb
+++ b/factsheets/template-engines/erb/examples/newline_control.erb
@@ -1,0 +1,4 @@
+<% [1, 2, 3, 4, 5].each do |i| -%>
+  Number: <%= i %>
+<% end -%>
+<%# The hyphen -%> suppresses the trailing newline %>

--- a/factsheets/template-engines/erb/examples/partial.erb
+++ b/factsheets/template-engines/erb/examples/partial.erb
@@ -1,0 +1,6 @@
+<div class="user-card">
+  <%= render partial: 'user_info', locals: { user: @user } %>
+  <div class="bio">
+    <%= @user.bio.html_safe %>
+  </div>
+</div>

--- a/factsheets/template-engines/liquid/README.md
+++ b/factsheets/template-engines/liquid/README.md
@@ -30,3 +30,13 @@ sudo apt install -y ruby-liquid
 ```bash
 /usr/bin/ruby -e 'require "liquid"; puts Liquid::VERSION'
 ```
+
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Liquid-Templates:
+
+1.  `basic.liquid`: Grundlegende Variablenersetzung und Filter.
+2.  `loop.liquid`: Iteration über Kollektionen mit `for`.
+3.  `conditional.liquid`: Bedingte Logik mit `if`, `elsif` und `unless`.
+4.  `filters.liquid`: Anwendung verschiedener eingebauter Filter (Datum, String-Manipulation, Mathe).
+5.  `assign_capture.liquid`: Variablenzuweisung, Text-Capturing und Einbinden von Partials.

--- a/factsheets/template-engines/liquid/examples/assign_capture.liquid
+++ b/factsheets/template-engines/liquid/examples/assign_capture.liquid
@@ -1,0 +1,9 @@
+{% assign my_variable = "tomato" %}
+{{ my_variable }}
+
+{% capture welcome_message %}
+  Hello {{ user.name }}, welcome to our store!
+{% endcapture %}
+{{ welcome_message }}
+
+{% include 'header', title: 'Home Page' %}

--- a/factsheets/template-engines/liquid/examples/basic.liquid
+++ b/factsheets/template-engines/liquid/examples/basic.liquid
@@ -1,0 +1,3 @@
+Hello {{ name | capitalize }}!
+Product: {{ product.title }}
+Price: {{ product.price | money }}

--- a/factsheets/template-engines/liquid/examples/conditional.liquid
+++ b/factsheets/template-engines/liquid/examples/conditional.liquid
@@ -1,0 +1,11 @@
+{% if user.name == 'elvis' %}
+  Hey Elvis!
+{% elsif user.name == 'anonymous' %}
+  Hey stranger!
+{% else %}
+  Hi {{ user.name }}!
+{% endif %}
+
+{% unless user.logged_in %}
+  Please log in.
+{% endunless %}

--- a/factsheets/template-engines/liquid/examples/filters.liquid
+++ b/factsheets/template-engines/liquid/examples/filters.liquid
@@ -1,0 +1,5 @@
+{{ "now" | date: "%Y-%m-%d %H:%M" }}
+{{ "Adam" | append: " & Eve" }}
+{{ "Ground Control" | split: " " | last }}
+{{ 4 | plus: 2 }}
+{{ "HELLO" | downcase }}

--- a/factsheets/template-engines/liquid/examples/loop.liquid
+++ b/factsheets/template-engines/liquid/examples/loop.liquid
@@ -1,0 +1,7 @@
+<ul>
+  {% for product in collection.products %}
+    <li>{{ product.title }} - {{ forloop.index }}</li>
+  {% else %}
+    <p>This collection is empty.</p>
+  {% endfor %}
+</ul>

--- a/factsheets/template-engines/pug/README.md
+++ b/factsheets/template-engines/pug/README.md
@@ -30,3 +30,13 @@ p Hello World
 ```bash
 pug --version
 ```
+
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Pug-Templates:
+
+1.  `basic.pug`: Grundlegende Syntax mit Einrückung, Attributen und Variablen.
+2.  `loop.pug`: Iteration über Arrays mit `each`.
+3.  `conditional.pug`: Bedingte Logik mit `if` und `else`.
+4.  `mixin.pug`: Wiederverwendbare Code-Blöcke (Mixins) mit Parametern.
+5.  `inheritance.pug`: Layout-Konzept mit `extends`, `block` und `include`.

--- a/factsheets/template-engines/pug/examples/basic.pug
+++ b/factsheets/template-engines/pug/examples/basic.pug
@@ -1,0 +1,16 @@
+doctype html
+html(lang="en")
+  head
+    title= pageTitle
+    script(type='text/javascript').
+      if (foo) bar(1 + 5)
+  body
+    h1 Pug - node template engine
+    #container.col
+      if youAreUsingPug
+        p You are amazing
+      else
+        p Get on it!
+      p.
+        Pug is a terse and simple templating language with a
+        strong focus on performance and powerful features.

--- a/factsheets/template-engines/pug/examples/conditional.pug
+++ b/factsheets/template-engines/pug/examples/conditional.pug
@@ -1,0 +1,10 @@
+- var user = { description: 'foo bar baz' }
+- var authorised = false
+#user
+  if authorised
+    h2 Description
+    p.description
+      = user.description
+  else
+    h2 Description
+    p.description User has no description

--- a/factsheets/template-engines/pug/examples/inheritance.pug
+++ b/factsheets/template-engines/pug/examples/inheritance.pug
@@ -1,0 +1,23 @@
+//- layout.pug
+html
+  head
+    title My Site - #{title}
+    block scripts
+      script(src='/jquery.js')
+  body
+    block content
+    block foot
+      #footer
+        p some footer content
+
+//- page.pug
+extends layout.pug
+
+block scripts
+  script(src='/jquery.js')
+  script(src='/pets.js')
+
+block content
+  h1= title
+  each pet in pets
+    include pet.pug

--- a/factsheets/template-engines/pug/examples/loop.pug
+++ b/factsheets/template-engines/pug/examples/loop.pug
@@ -1,0 +1,9 @@
+ul
+  each val, index in ['zero', 'one', 'two']
+    li= index + ': ' + val
+
+ul
+  each val in []
+    li= val
+  else
+    li There are no values

--- a/factsheets/template-engines/pug/examples/mixin.pug
+++ b/factsheets/template-engines/pug/examples/mixin.pug
@@ -1,0 +1,15 @@
+mixin list
+  ul
+    li foo
+    li bar
+    li baz
+
++list
++list
+
+mixin pet(name)
+  li.pet= name
+ul
+  +pet('cat')
+  +pet('dog')
+  +pet('pig')

--- a/factsheets/template-engines/razor/README.md
+++ b/factsheets/template-engines/razor/README.md
@@ -30,3 +30,13 @@ sudo apt install -y dotnet-sdk-8.0
 ```bash
 dotnet --version
 ```
+
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Razor-Templates (`.cshtml`):
+
+1.  `basic.cshtml`: Grundlegende Syntax mit Modellen, Datumsausgabe und Null-Coalescing.
+2.  `loop.cshtml`: Verwendung von `@foreach` und `@for` Schleifen zur Iteration.
+3.  `conditional.cshtml`: Bedingte Logik mit `@if`/`@else` und `@switch`.
+4.  `layout.cshtml`: Definition eines Layouts mit `@RenderBody()` und `@RenderSection()`.
+5.  `partial.cshtml`: Erstellung eines wiederverwendbaren Partials.

--- a/factsheets/template-engines/razor/examples/basic.cshtml
+++ b/factsheets/template-engines/razor/examples/basic.cshtml
@@ -1,0 +1,5 @@
+@model Project.Models.User
+
+<h1>Hello @Model.Name</h1>
+<p>Today is @DateTime.Now.ToShortDateString()</p>
+<p>Email: @(Model.Email ?? "No email provided")</p>

--- a/factsheets/template-engines/razor/examples/conditional.cshtml
+++ b/factsheets/template-engines/razor/examples/conditional.cshtml
@@ -1,0 +1,18 @@
+@if (User.Identity.IsAuthenticated)
+{
+    <p>Welcome back, @User.Identity.Name!</p>
+}
+else
+{
+    <p>Please log in.</p>
+}
+
+@switch (Model.Status)
+{
+    case Status.Active:
+        <span>Active</span>
+        break;
+    default:
+        <span>Inactive</span>
+        break;
+}

--- a/factsheets/template-engines/razor/examples/layout.cshtml
+++ b/factsheets/template-engines/razor/examples/layout.cshtml
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>@ViewData["Title"] - My ASP.NET Application</title>
+</head>
+<body>
+    <header>
+        <nav>...</nav>
+    </header>
+    <div class="container">
+        @RenderBody()
+    </div>
+    <footer>
+        @RenderSection("Scripts", required: false)
+    </footer>
+</body>
+</html>

--- a/factsheets/template-engines/razor/examples/loop.cshtml
+++ b/factsheets/template-engines/razor/examples/loop.cshtml
@@ -1,0 +1,13 @@
+@model IEnumerable<Project.Models.Item>
+
+<ul>
+    @foreach (var item in Model)
+    {
+        <li>@item.Name - @item.Price.ToString("C")</li>
+    }
+</ul>
+
+@for (int i = 0; i < 5; i++)
+{
+    <p>Iteration @i</p>
+}

--- a/factsheets/template-engines/razor/examples/partial.cshtml
+++ b/factsheets/template-engines/razor/examples/partial.cshtml
@@ -1,0 +1,6 @@
+<div class="alert alert-info">
+    @Model.Message
+</div>
+
+@* Usage in another view: *@
+@* <partial name="_Alert" model='new AlertModel { Message = "Success!" }' /> *@

--- a/factsheets/template-engines/thymeleaf/README.md
+++ b/factsheets/template-engines/thymeleaf/README.md
@@ -31,3 +31,13 @@ sudo apt install -y maven
 ```bash
 mvn --version
 ```
+
+## Beispiele
+
+Im Ordner `examples/` befinden sich verschiedene Thymeleaf-Templates (`.html`):
+
+1.  `basic.html`: Grundlegende Textausgabe, Attribut-Handling und URL-Generierung.
+2.  `loop.html`: Iteration über Listen mit `th:each`.
+3.  `conditional.html`: Bedingte Anzeige mit `th:if`, `th:unless` und `th:switch`.
+4.  `fragment.html`: Definition und Verwendung von wiederverwendbaren Fragmenten (`th:fragment`).
+5.  `expression_objects.html`: Verwendung von eingebauten Objekten wie `#calendars`, `#strings` und `#lists`.

--- a/factsheets/template-engines/thymeleaf/examples/basic.html
+++ b/factsheets/template-engines/thymeleaf/examples/basic.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Thymeleaf Example</title>
+</head>
+<body>
+    <p th:text="'Hello, ' + ${name} + '!'">Hello, Guest!</p>
+    <p>Age: <span th:text="${user.age}">25</span></p>
+    <a th:href="@{/profile(id=${user.id})}">View Profile</a>
+</body>
+</html>

--- a/factsheets/template-engines/thymeleaf/examples/conditional.html
+++ b/factsheets/template-engines/thymeleaf/examples/conditional.html
@@ -1,0 +1,12 @@
+<div th:if="${user.isAdmin()}">
+    <p>Welcome, Administrator!</p>
+</div>
+<div th:unless="${user.isSubscribed()}">
+    <p>Please subscribe to our newsletter.</p>
+</div>
+
+<div th:switch="${user.role}">
+  <p th:case="'ADMIN'">User is an admin</p>
+  <p th:case="'USER'">User is a standard user</p>
+  <p th:case="*">User has an unknown role</p>
+</div>

--- a/factsheets/template-engines/thymeleaf/examples/expression_objects.html
+++ b/factsheets/template-engines/thymeleaf/examples/expression_objects.html
@@ -1,0 +1,5 @@
+<p th:text="${#calendars.format(today, 'dd/MMM/yyyy HH:mm')}">13/Jan/2011 14:30</p>
+<p th:text="${#strings.toUpperCase(name)}">NAME</p>
+<ul th:if="${not #lists.isEmpty(users)}">
+    <li th:text="${#lists.size(users)}">3</li>
+</ul>

--- a/factsheets/template-engines/thymeleaf/examples/fragment.html
+++ b/factsheets/template-engines/thymeleaf/examples/fragment.html
@@ -1,0 +1,7 @@
+<footer th:fragment="copy">
+  &copy; 2024 The Good Thymes Virtual Grocery
+</footer>
+
+<!-- Inclusion in another file: -->
+<!-- <div th:insert="~{footer :: copy}"></div> -->
+<!-- <div th:replace="~{footer :: copy}"></div> -->

--- a/factsheets/template-engines/thymeleaf/examples/loop.html
+++ b/factsheets/template-engines/thymeleaf/examples/loop.html
@@ -1,0 +1,14 @@
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Email</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr th:each="user : ${users}">
+      <td th:text="${user.name}">John Doe</td>
+      <td th:text="${user.email}">john@example.com</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
This PR supplements missing examples for 11 key tools in the factsheets, addressing a major gap identified in the roadmap.

Changes:
- Created `examples/` directories for Blade, ERB, Liquid, Pug, Razor, Thymeleaf, Java, Node.js, Maven, Ant, and Composer.
- Added 5 high-quality, idiomatic example files per tool covering common use cases.
- Updated the `README.md` for each of these tools with a `## Beispiele` section.
- Synchronized repository metadata by running maintenance scripts (`analyze_factsheets.py`, `generate_summaries.py`, `generate_mkdocs_config.py`).
- Updated `.gitignore` to exclude documentation build artifacts.
- Verified that the documentation site builds successfully with the new content.

Fixes #208

---
*PR created automatically by Jules for task [8270045766278440496](https://jules.google.com/task/8270045766278440496) started by @chatelao*