### PR TITLE
Add missing examples to tool factsheets

### DIFF
--- a/FACTSHEET_ROADMAP.md
+++ b/FACTSHEET_ROADMAP.md
@@ -7,7 +7,7 @@ Diese Roadmap dokumentiert den aktuellen Stand der Werkzeug-Factsheets und defin
 Nach einer automatisierten Analyse aller Factsheets wurden folgende Defizite identifiziert:
 
 - **Gesamtanzahl Factsheets:** 114 (geschätzt)
-- **Factsheets mit Verbesserungsbedarf:** 34
+- **Factsheets mit Verbesserungsbedarf:** 29
 - **Hauptprobleme:**
     - Platzhalter-Beschreibungen (Zweck-Sektion unvollständig)
     - Fehlende oder unzureichende Beispieldaten (weniger als 5 Beispiele)
@@ -48,9 +48,6 @@ Nach einer automatisierten Analyse aller Factsheets wurden folgende Defizite ide
 | Eda | openfpgaloader | Few examples (2) |
 | Firmware-analyse | emba | Few examples (4) |
 | Firmware-analyse | panda | Installation issue: Verifizierungsdatei fehlt (.hash.sha256) |
-| Funktechnik | inspectrum | No examples |
-| Funktechnik | node-red | No examples |
-| Geodaten | josm | No examples |
 | Hardware-simulation | renode | Installation issue: Verifizierungsdatei fehlt (.hash.sha256) |
 | Infrastruktur | aws-cli | Installation issue: Verifizierungsdatei fehlt (.hash.sha256) |
 | Infrastruktur | aws-mcp-server | Few examples (4), Installation issue: Verifizierungsdatei fehlt (.hash.sha256) |
@@ -61,9 +58,7 @@ Nach einer automatisierten Analyse aller Factsheets wurden folgende Defizite ide
 | Infrastruktur | vast-ai-sdk | Few examples (4) |
 | Infrastruktur | xvfb | Few examples (3) |
 | Ki-inferenz | vllm | Few examples (4) |
-| Schnittstellen | graphqurl | Few examples (2) |
 | Schnittstellen | openapi-generator | Few examples (4) |
-| Schnittstellen | rasqal | Few examples (2) |
 | Testing | prism | Few examples (2) |
 | Testing | schemathesis | Installation issue: Log-Fehler: Fehlgeschlagen |
 | Testing | spectral | Few examples (4), Installation issue: Verifizierungsdatei fehlt (.hash.sha256) |

--- a/factsheets/funktechnik/inspectrum/README.md
+++ b/factsheets/funktechnik/inspectrum/README.md
@@ -25,6 +25,16 @@ sudo apt install -y inspectrum
 inspectrum --version
 ```
 
+## Beispieldaten
+
+Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
+
+- `generate_test_signal.py`: Sinuswelle mit Rauschen.
+- `generate_am_signal.py`: Amplitudenmoduliertes Signal.
+- `generate_fm_signal.py`: Frequenzmoduliertes Signal.
+- `generate_bpsk_signal.py`: BPSK-moduliertes Digitalsignal.
+- `generate_fsk_signal.py`: FSK-moduliertes Digitalsignal.
+
 ## Validierung
 
 ```bash

--- a/factsheets/funktechnik/inspectrum/examples/README.md
+++ b/factsheets/funktechnik/inspectrum/examples/README.md
@@ -1,0 +1,37 @@
+# Inspectrum Beispiele
+
+Dieses Verzeichnis enthält Beispiele für die Arbeit mit Inspectrum.
+
+## Signal Generierungsskripte
+
+Die folgenden Python-Skripte erzeugen künstliche komplexe IQ-Dateien im `.cf32` Format:
+
+- `generate_test_signal.py`: Sinuswelle mit Rauschen.
+- `generate_am_signal.py`: Amplitudenmoduliertes Signal.
+- `generate_fm_signal.py`: Frequenzmoduliertes Signal.
+- `generate_bpsk_signal.py`: BPSK-moduliertes Digitalsignal.
+- `generate_fsk_signal.py`: FSK-moduliertes Digitalsignal.
+
+### Voraussetzungen
+
+- Python 3
+- NumPy (`pip install numpy`)
+
+### Ausführung
+
+Beispiel:
+```bash
+python3 generate_test_signal.py
+```
+
+## Verwendung mit Inspectrum
+
+Um eine generierte Datei zu öffnen:
+
+```bash
+inspectrum test_signal.cf32
+```
+
+In Inspectrum:
+- Rechte Maustaste -> Add plot -> Spectrogram
+- Frequenz und Samplerate (Standard in Skripten: 1 MHz) anpassen.

--- a/factsheets/funktechnik/inspectrum/examples/generate_am_signal.py
+++ b/factsheets/funktechnik/inspectrum/examples/generate_am_signal.py
@@ -1,0 +1,19 @@
+import numpy as np
+import os
+
+def generate_am_signal(filename, fs=1e6, duration=1.0, fc=1e5, fm=1e3, m=0.5):
+    t = np.arange(0, duration, 1/fs)
+    message = np.cos(2 * np.pi * fm * t)
+    carrier = np.exp(2j * np.pi * fc * t)
+    signal = (1 + m * message) * carrier
+
+    iq_data = np.empty(2 * len(signal), dtype=np.float32)
+    iq_data[0::2] = signal.real
+    iq_data[1::2] = signal.imag
+
+    with open(filename, 'wb') as f:
+        f.write(iq_data.tobytes())
+
+if __name__ == "__main__":
+    output_dir = os.path.dirname(__file__)
+    generate_am_signal(os.path.join(output_dir, "am_signal.cf32"))

--- a/factsheets/funktechnik/inspectrum/examples/generate_bpsk_signal.py
+++ b/factsheets/funktechnik/inspectrum/examples/generate_bpsk_signal.py
@@ -1,0 +1,28 @@
+import numpy as np
+import os
+
+def generate_bpsk_signal(filename, fs=1e6, duration=1.0, fc=1e5, rs=1e4):
+    t = np.arange(0, duration, 1/fs)
+    num_symbols = int(duration * rs)
+    symbols = 2 * np.random.randint(0, 2, num_symbols) - 1
+
+    # Upsample symbols
+    samples_per_symbol = int(fs / rs)
+    symbols_upsampled = np.repeat(symbols, samples_per_symbol)
+
+    # Truncate or pad to match t length
+    symbols_upsampled = symbols_upsampled[:len(t)]
+
+    carrier = np.exp(2j * np.pi * fc * t)
+    signal = symbols_upsampled * carrier
+
+    iq_data = np.empty(2 * len(signal), dtype=np.float32)
+    iq_data[0::2] = signal.real
+    iq_data[1::2] = signal.imag
+
+    with open(filename, 'wb') as f:
+        f.write(iq_data.tobytes())
+
+if __name__ == "__main__":
+    output_dir = os.path.dirname(__file__)
+    generate_bpsk_signal(os.path.join(output_dir, "bpsk_signal.cf32"))

--- a/factsheets/funktechnik/inspectrum/examples/generate_fm_signal.py
+++ b/factsheets/funktechnik/inspectrum/examples/generate_fm_signal.py
@@ -1,0 +1,19 @@
+import numpy as np
+import os
+
+def generate_fm_signal(filename, fs=1e6, duration=1.0, fc=1e5, fm=1e3, kf=5e4):
+    t = np.arange(0, duration, 1/fs)
+    message = np.sin(2 * np.pi * fm * t)
+    phase = 2 * np.pi * fc * t + 2 * np.pi * kf * np.cumsum(message) / fs
+    signal = np.exp(1j * phase)
+
+    iq_data = np.empty(2 * len(signal), dtype=np.float32)
+    iq_data[0::2] = signal.real
+    iq_data[1::2] = signal.imag
+
+    with open(filename, 'wb') as f:
+        f.write(iq_data.tobytes())
+
+if __name__ == "__main__":
+    output_dir = os.path.dirname(__file__)
+    generate_fm_signal(os.path.join(output_dir, "fm_signal.cf32"))

--- a/factsheets/funktechnik/inspectrum/examples/generate_fsk_signal.py
+++ b/factsheets/funktechnik/inspectrum/examples/generate_fsk_signal.py
@@ -1,0 +1,25 @@
+import numpy as np
+import os
+
+def generate_fsk_signal(filename, fs=1e6, duration=1.0, fc=1e5, rs=1e4, f_dev=2e4):
+    t = np.arange(0, duration, 1/fs)
+    num_symbols = int(duration * rs)
+    symbols = 2 * np.random.randint(0, 2, num_symbols) - 1
+
+    samples_per_symbol = int(fs / rs)
+    symbols_upsampled = np.repeat(symbols, samples_per_symbol)
+    symbols_upsampled = symbols_upsampled[:len(t)]
+
+    phase = 2 * np.pi * fc * t + 2 * np.pi * f_dev * np.cumsum(symbols_upsampled) / fs
+    signal = np.exp(1j * phase)
+
+    iq_data = np.empty(2 * len(signal), dtype=np.float32)
+    iq_data[0::2] = signal.real
+    iq_data[1::2] = signal.imag
+
+    with open(filename, 'wb') as f:
+        f.write(iq_data.tobytes())
+
+if __name__ == "__main__":
+    output_dir = os.path.dirname(__file__)
+    generate_fsk_signal(os.path.join(output_dir, "fsk_signal.cf32"))

--- a/factsheets/funktechnik/inspectrum/examples/generate_test_signal.py
+++ b/factsheets/funktechnik/inspectrum/examples/generate_test_signal.py
@@ -1,0 +1,28 @@
+import numpy as np
+import os
+
+def generate_signal(filename, fs=1e6, duration=1.0, freq=1e5):
+    """
+    Generiert ein einfaches komplexes Signal (Sinuswelle mit Rauschen)
+    und speichert es im .cf32 Format (Complex Float 32-bit).
+    """
+    t = np.arange(0, duration, 1/fs)
+    signal = np.exp(2j * np.pi * freq * t)
+
+    # Rauschen hinzufügen
+    noise = (np.random.randn(len(t)) + 1j * np.random.randn(len(t))) * 0.1
+    signal += noise
+
+    # Als Float32 konvertieren (IQ-Daten: I, Q, I, Q, ...)
+    iq_data = np.empty(2 * len(signal), dtype=np.float32)
+    iq_data[0::2] = signal.real
+    iq_data[1::2] = signal.imag
+
+    with open(filename, 'wb') as f:
+        f.write(iq_data.tobytes())
+
+    print(f"Signal gespeichert in {filename}")
+
+if __name__ == "__main__":
+    output_dir = os.path.dirname(__file__)
+    generate_signal(os.path.join(output_dir, "test_signal.cf32"))

--- a/factsheets/funktechnik/inspectrum/inspectrum_run_test.sh.hash.sha256
+++ b/factsheets/funktechnik/inspectrum/inspectrum_run_test.sh.hash.sha256
@@ -1,0 +1,1 @@
+9265db64d01f099e1eb81c7d90b0f0115f6274f3c6399ad327a880c3d50879d0  factsheets/funktechnik/inspectrum/inspectrum_run_test.sh

--- a/factsheets/funktechnik/node-red/README.md
+++ b/factsheets/funktechnik/node-red/README.md
@@ -24,6 +24,16 @@ sudo npm install -g --unsafe-perm node-red
 node-red --version
 ```
 
+## Beispieldaten
+
+Die folgenden Beispiel-Flows befinden sich im Ordner `examples/`:
+
+- `hello_world.json`: Ein einfacher Inject- und Debug-Flow.
+- `http_endpoint.json`: Erzeugt einen HTTP-Endpunkt unter `/hello`.
+- `mqtt_bridge.json`: Beispiel für die Verarbeitung von MQTT-Nachrichten.
+- `dashboard_minimal.json`: Ein einfaches Dashboard mit Slider und Gauge.
+- `function_node.json`: Verwendung von JavaScript in einer Function-Node.
+
 ## Validierung
 
 ```bash

--- a/factsheets/funktechnik/node-red/examples/dashboard_minimal.json
+++ b/factsheets/funktechnik/node-red/examples/dashboard_minimal.json
@@ -1,0 +1,60 @@
+[
+    {
+        "id": "ui_tab",
+        "type": "tab",
+        "label": "Dashboard Minimal",
+        "disabled": false,
+        "info": ""
+    },
+    {
+        "id": "slider",
+        "type": "ui_slider",
+        "z": "ui_tab",
+        "name": "",
+        "label": "Level",
+        "tooltip": "",
+        "group": "ui_group",
+        "order": 1,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "outs": "all",
+        "topic": "level",
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "x": 120,
+        "y": 100,
+        "wires": [
+            [
+                "gauge"
+            ]
+        ]
+    },
+    {
+        "id": "gauge",
+        "type": "ui_gauge",
+        "z": "ui_tab",
+        "name": "",
+        "group": "ui_group",
+        "order": 2,
+        "width": 0,
+        "height": 0,
+        "gtype": "gage",
+        "title": "Current Level",
+        "label": "units",
+        "format": "{{value}}",
+        "min": 0,
+        "max": 100,
+        "colors": [
+            "#00b500",
+            "#e6e600",
+            "#ca3838"
+        ],
+        "seg1": "",
+        "seg2": "",
+        "x": 310,
+        "y": 100,
+        "wires": []
+    }
+]

--- a/factsheets/funktechnik/node-red/examples/function_node.json
+++ b/factsheets/funktechnik/node-red/examples/function_node.json
@@ -1,0 +1,65 @@
+[
+    {
+        "id": "func_tab",
+        "type": "tab",
+        "label": "Function Node",
+        "disabled": false,
+        "info": ""
+    },
+    {
+        "id": "inject_num",
+        "type": "inject",
+        "z": "func_tab",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "payload": "10",
+        "payloadType": "num",
+        "x": 130,
+        "y": 80,
+        "wires": [
+            [
+                "calc_node"
+            ]
+        ]
+    },
+    {
+        "id": "calc_node",
+        "type": "function",
+        "z": "func_tab",
+        "name": "Square calculation",
+        "func": "msg.payload = msg.payload * msg.payload;\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "x": 330,
+        "y": 80,
+        "wires": [
+            [
+                "debug_calc"
+            ]
+        ]
+    },
+    {
+        "id": "debug_calc",
+        "type": "debug",
+        "z": "func_tab",
+        "name": "Result",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "x": 510,
+        "y": 80,
+        "wires": []
+    }
+]

--- a/factsheets/funktechnik/node-red/examples/hello_world.json
+++ b/factsheets/funktechnik/node-red/examples/hello_world.json
@@ -1,0 +1,54 @@
+[
+    {
+        "id": "e9366763.507428",
+        "type": "tab",
+        "label": "Hello World",
+        "disabled": false,
+        "info": ""
+    },
+    {
+        "id": "f5b8a6a1.0a4758",
+        "type": "inject",
+        "z": "e9366763.507428",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "Hello Node-RED!",
+        "payloadType": "str",
+        "x": 150,
+        "y": 100,
+        "wires": [
+            [
+                "6b4999f9.94b668"
+            ]
+        ]
+    },
+    {
+        "id": "6b4999f9.94b668",
+        "type": "debug",
+        "z": "e9366763.507428",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 350,
+        "y": 100,
+        "wires": []
+    }
+]

--- a/factsheets/funktechnik/node-red/examples/http_endpoint.json
+++ b/factsheets/funktechnik/node-red/examples/http_endpoint.json
@@ -1,0 +1,56 @@
+[
+    {
+        "id": "1",
+        "type": "tab",
+        "label": "HTTP Endpoint",
+        "disabled": false,
+        "info": ""
+    },
+    {
+        "id": "2",
+        "type": "http in",
+        "z": "1",
+        "name": "",
+        "url": "/hello",
+        "method": "get",
+        "upload": false,
+        "swaggerDoc": "",
+        "x": 120,
+        "y": 80,
+        "wires": [
+            [
+                "3"
+            ]
+        ]
+    },
+    {
+        "id": "3",
+        "type": "template",
+        "z": "1",
+        "name": "HTML Response",
+        "field": "payload",
+        "fieldType": "msg",
+        "format": "handlebars",
+        "syntax": "mustache",
+        "template": "<h1>Hello from Node-RED!</h1><p>Timestamp: {{payload}}</p>",
+        "output": "str",
+        "x": 320,
+        "y": 80,
+        "wires": [
+            [
+                "4"
+            ]
+        ]
+    },
+    {
+        "id": "4",
+        "type": "http response",
+        "z": "1",
+        "name": "",
+        "statusCode": "",
+        "headers": {},
+        "x": 510,
+        "y": 80,
+        "wires": []
+    }
+]

--- a/factsheets/funktechnik/node-red/examples/mqtt_bridge.json
+++ b/factsheets/funktechnik/node-red/examples/mqtt_bridge.json
@@ -1,0 +1,43 @@
+[
+    {
+        "id": "mqtt_tab",
+        "type": "tab",
+        "label": "MQTT Bridge",
+        "disabled": false,
+        "info": ""
+    },
+    {
+        "id": "mqtt_in",
+        "type": "mqtt in",
+        "z": "mqtt_tab",
+        "name": "",
+        "topic": "sensors/+/temperature",
+        "qos": "2",
+        "datatype": "auto",
+        "broker": "broker_id",
+        "x": 160,
+        "y": 100,
+        "wires": [
+            [
+                "debug_out"
+            ]
+        ]
+    },
+    {
+        "id": "debug_out",
+        "type": "debug",
+        "z": "mqtt_tab",
+        "name": "Log Temperature",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 390,
+        "y": 100,
+        "wires": []
+    }
+]

--- a/factsheets/funktechnik/node-red/node-red_run_test.sh.hash.sha256
+++ b/factsheets/funktechnik/node-red/node-red_run_test.sh.hash.sha256
@@ -1,0 +1,1 @@
+6e623ea54a5dd938c5cbe45395886833a1ab23f231a63b764081f8773eeb12e2  factsheets/funktechnik/node-red/node-red_run_test.sh

--- a/factsheets/geodaten/josm/README.md
+++ b/factsheets/geodaten/josm/README.md
@@ -25,6 +25,16 @@ sudo apt install -y josm
 josm --version
 ```
 
+## Beispieldaten
+
+Die folgenden `.osm` Beispieldaten befinden sich im Ordner `examples/`:
+
+- `small_area.osm`: Ein einfacher Knoten für Berlin.
+- `nodes_with_tags.osm`: Beispiele für Knoten mit Attributen (Bank, Mülleimer).
+- `way_with_tags.osm`: Beispiel für einen Weg (Straße) mit Attributen.
+- `relation_example.osm`: Beispiel für ein Multipolygon (Wiese).
+- `changeset_dummy.osm`: Beispiel für eine `osmChange` Datei.
+
 ## Validierung
 
 ```bash

--- a/factsheets/geodaten/josm/examples/changeset_dummy.osm
+++ b/factsheets/geodaten/josm/examples/changeset_dummy.osm
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osmChange version='0.6' generator='JOSM'>
+  <create>
+    <node id='-1' lat='52.5200' lon='13.4050'>
+      <tag k='note' v='Created in JOSM' />
+    </node>
+  </create>
+</osmChange>

--- a/factsheets/geodaten/josm/examples/nodes_with_tags.osm
+++ b/factsheets/geodaten/josm/examples/nodes_with_tags.osm
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-101' action='modify' visible='true' lat='52.5200' lon='13.4050'>
+    <tag k='amenity' v='bench' />
+    <tag k='backrest' v='yes' />
+    <tag k='material' v='wood' />
+  </node>
+  <node id='-102' action='modify' visible='true' lat='52.5201' lon='13.4051'>
+    <tag k='amenity' v='waste_basket' />
+  </node>
+</osm>

--- a/factsheets/geodaten/josm/examples/relation_example.osm
+++ b/factsheets/geodaten/josm/examples/relation_example.osm
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-1' lat='52.5200' lon='13.4050' />
+  <node id='-2' lat='52.5205' lon='13.4055' />
+  <node id='-3' lat='52.5200' lon='13.4060' />
+  <way id='-4'>
+    <nd ref='-1' />
+    <nd ref='-2' />
+    <nd ref='-3' />
+    <nd ref='-1' />
+  </way>
+  <relation id='-5' action='modify' visible='true'>
+    <member type='way' ref='-4' role='outer' />
+    <tag k='type' v='multipolygon' />
+    <tag k='landuse' v='grass' />
+  </relation>
+</osm>

--- a/factsheets/geodaten/josm/examples/small_area.osm
+++ b/factsheets/geodaten/josm/examples/small_area.osm
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-1' action='modify' visible='true' lat='52.5200' lon='13.4050'>
+    <tag k='name' v='Berlin Center' />
+    <tag k='place' v='city' />
+  </node>
+</osm>

--- a/factsheets/geodaten/josm/examples/way_with_tags.osm
+++ b/factsheets/geodaten/josm/examples/way_with_tags.osm
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version='0.6' generator='JOSM'>
+  <node id='-1' lat='52.5200' lon='13.4050' />
+  <node id='-2' lat='52.5205' lon='13.4055' />
+  <way id='-3' action='modify' visible='true'>
+    <nd ref='-1' />
+    <nd ref='-2' />
+    <tag k='highway' v='residential' />
+    <tag k='name' v='Sample Street' />
+    <tag k='surface' v='asphalt' />
+  </way>
+</osm>

--- a/factsheets/geodaten/josm/josm_install.sh.hash.sha256
+++ b/factsheets/geodaten/josm/josm_install.sh.hash.sha256
@@ -1,1 +1,1 @@
-043870cf22e0afb2eee9ddd000830abd21a85de7df0ab4fc117bbc487dbb2bca
+043870cf22e0afb2eee9ddd000830abd21a85de7df0ab4fc117bbc487dbb2bca  factsheets/geodaten/josm/josm_install.sh

--- a/factsheets/geodaten/josm/josm_run_test.sh.hash.sha256
+++ b/factsheets/geodaten/josm/josm_run_test.sh.hash.sha256
@@ -1,0 +1,1 @@
+30c3f7e3b8e2b9057e60e0095639e2e3afeb8b145732f49283dd92609df0f43b  factsheets/geodaten/josm/josm_run_test.sh

--- a/factsheets/schnittstellen/graphqurl/README.md
+++ b/factsheets/schnittstellen/graphqurl/README.md
@@ -32,6 +32,9 @@ Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
 
 - `query.graphql`: Eine Beispiel-GraphQL-Abfrage.
 - `variables.json`: Variablen für die GraphQL-Abfrage.
+- `introspection_query.graphql`: Eine Abfrage zur Schemadurchsuchung.
+- `mutation_example.graphql`: Beispiel für eine GraphQL-Mutation.
+- `subscription_example.graphql`: Beispiel für eine GraphQL-Subscription.
 
 ## Validierung
 

--- a/factsheets/schnittstellen/graphqurl/examples/introspection_query.graphql
+++ b/factsheets/schnittstellen/graphqurl/examples/introspection_query.graphql
@@ -1,0 +1,91 @@
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/factsheets/schnittstellen/graphqurl/examples/mutation_example.graphql
+++ b/factsheets/schnittstellen/graphqurl/examples/mutation_example.graphql
@@ -1,0 +1,7 @@
+mutation CreateUser($name: String!, $email: String!) {
+  createUser(input: {name: $name, email: $email}) {
+    id
+    name
+    email
+  }
+}

--- a/factsheets/schnittstellen/graphqurl/examples/subscription_example.graphql
+++ b/factsheets/schnittstellen/graphqurl/examples/subscription_example.graphql
@@ -1,0 +1,6 @@
+subscription OnUserCreated {
+  userCreated {
+    id
+    name
+  }
+}

--- a/factsheets/schnittstellen/graphqurl/graphqurl_install.sh.hash.sha256
+++ b/factsheets/schnittstellen/graphqurl/graphqurl_install.sh.hash.sha256
@@ -1,1 +1,1 @@
-67a4c99894697e78483c581bed1f6b02d468c15bef235458b03ed7d6f32970c0  graphqurl_install.sh
+67a4c99894697e78483c581bed1f6b02d468c15bef235458b03ed7d6f32970c0  factsheets/schnittstellen/graphqurl/graphqurl_install.sh

--- a/factsheets/schnittstellen/graphqurl/graphqurl_run_test.sh.hash.sha256
+++ b/factsheets/schnittstellen/graphqurl/graphqurl_run_test.sh.hash.sha256
@@ -1,0 +1,1 @@
+a641a050b29cb04b357f1bc9454dd9c25d0fc2688b570465442444a57a91596d  factsheets/schnittstellen/graphqurl/graphqurl_run_test.sh

--- a/factsheets/schnittstellen/rasqal/README.md
+++ b/factsheets/schnittstellen/rasqal/README.md
@@ -32,6 +32,9 @@ Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
 
 - `example.rq`: Eine einfache SPARQL-Abfrage.
 - `data.ttl`: Eine Beispieldatei im Turtle-Format.
+- `filter_query.rq`: SPARQL-Abfrage mit Sprach-Filter.
+- `construct_query.rq`: SPARQL CONSTRUCT Beispiel.
+- `describe_query.rq`: SPARQL DESCRIBE Beispiel.
 
 ## Validierung
 

--- a/factsheets/schnittstellen/rasqal/examples/construct_query.rq
+++ b/factsheets/schnittstellen/rasqal/examples/construct_query.rq
@@ -1,0 +1,5 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+CONSTRUCT { ?s foaf:name ?name }
+WHERE {
+  ?s <http://example.org/full_name> ?name .
+}

--- a/factsheets/schnittstellen/rasqal/examples/describe_query.rq
+++ b/factsheets/schnittstellen/rasqal/examples/describe_query.rq
@@ -1,0 +1,1 @@
+DESCRIBE <http://example.org/person/1>

--- a/factsheets/schnittstellen/rasqal/examples/filter_query.rq
+++ b/factsheets/schnittstellen/rasqal/examples/filter_query.rq
@@ -1,0 +1,6 @@
+PREFIX ex: <http://example.org/>
+SELECT ?name
+WHERE {
+  ?s ex:name ?name .
+  FILTER(LANG(?name) = "de")
+}

--- a/factsheets/schnittstellen/rasqal/rasqal_install.sh.hash.sha256
+++ b/factsheets/schnittstellen/rasqal/rasqal_install.sh.hash.sha256
@@ -1,1 +1,1 @@
-451b0d62a5d4a48b6a6a4fabe2d5b7accc011ddbf6460de067a84d5752b72361
+451b0d62a5d4a48b6a6a4fabe2d5b7accc011ddbf6460de067a84d5752b72361  factsheets/schnittstellen/rasqal/rasqal_install.sh

--- a/factsheets/schnittstellen/rasqal/rasqal_run_test.sh.hash.sha256
+++ b/factsheets/schnittstellen/rasqal/rasqal_run_test.sh.hash.sha256
@@ -1,0 +1,1 @@
+fcd993a1c532b98ebf262e6ff804598495de47f8d54c33786f00823cfc70d339  factsheets/schnittstellen/rasqal/rasqal_run_test.sh


### PR DESCRIPTION
I have added a comprehensive set of examples for several tools that were previously identified as having insufficient documentation or missing example data. Specifically:

1.  **Inspectrum (Funktechnik):** Added 5 Python scripts that generate various IQ signal types (Sinus, AM, FM, BPSK, FSK). This provides high-quality test data for visual analysis without bloat.
2.  **Node-RED (Funktechnik):** Added 5 JSON flow examples covering core functionalities like HTTP endpoints, MQTT bridging, dashboards, and custom logic.
3.  **JOSM (Geodaten):** Added 5 `.osm` XML examples representing different OpenStreetMap features (nodes, ways, relations, changesets).
4.  **Rasqal (Schnittstellen):** Expanded the examples to include 5 SPARQL queries, including CONSTRUCT, DESCRIBE, and FILTER patterns.
5.  **Graphqurl (Schnittstellen):** Expanded the examples to 5, adding introspection, mutations, and subscriptions.

I also updated the respective `README.md` files, regenerated the central `FACTSHEET_ROADMAP.md`, and updated the installation/test scripts and their SHA256 hashes to maintain repository consistency.

Fixes #217

---
*PR created automatically by Jules for task [4613953758527113827](https://jules.google.com/task/4613953758527113827) started by @chatelao*