### PR TITLE
Update FACTSHEET_ROADMAP.md with dynamic counting

### DIFF
--- a/FACTSHEET_ROADMAP.md
+++ b/FACTSHEET_ROADMAP.md
@@ -6,7 +6,7 @@ Diese Roadmap dokumentiert den aktuellen Stand der Werkzeug-Factsheets und defin
 
 Nach einer automatisierten Analyse aller Factsheets wurden folgende Defizite identifiziert:
 
-- **Gesamtanzahl Factsheets:** 114 (geschätzt)
+- **Gesamtanzahl Factsheets:** 114
 - **Factsheets mit Verbesserungsbedarf:** 4
 - **Hauptprobleme:**
     - Platzhalter-Beschreibungen (Zweck-Sektion unvollständig)

--- a/scripts/analyze_factsheets.py
+++ b/scripts/analyze_factsheets.py
@@ -33,6 +33,7 @@ def analyze():
                 fixme_info[tool.lower()] = 'Listed in FIXME.md'
 
     roadmap_data = []
+    total_factsheets = 0
 
     for category in os.listdir(factsheets_root):
         cat_path = os.path.join(factsheets_root, category)
@@ -48,6 +49,7 @@ def analyze():
             if not os.path.exists(readme_path):
                 continue
 
+            total_factsheets += 1
             group, tool_name = category, tool
 
             with open(readme_path, 'r') as f:
@@ -93,9 +95,9 @@ def analyze():
 
     # Sort by group then tool
     roadmap_data.sort(key=lambda x: (x['group'], x['tool']))
-    return roadmap_data
+    return roadmap_data, total_factsheets
 
-def generate_roadmap(roadmap_data):
+def generate_roadmap(roadmap_data, total_factsheets):
     content = """# Roadmap für Factsheet-Verbesserungen
 
 Diese Roadmap dokumentiert den aktuellen Stand der Werkzeug-Factsheets und definiert Meilensteine zur Erreichung einer vollständigen und qualitativ hochwertigen Dokumentation gemäß [GEMINI.md](GEMINI.md).
@@ -104,7 +106,7 @@ Diese Roadmap dokumentiert den aktuellen Stand der Werkzeug-Factsheets und defin
 
 Nach einer automatisierten Analyse aller Factsheets wurden folgende Defizite identifiziert:
 
-- **Gesamtanzahl Factsheets:** 114 (geschätzt)
+- **Gesamtanzahl Factsheets:** """ + str(total_factsheets) + """
 - **Factsheets mit Verbesserungsbedarf:** """ + str(len(roadmap_data)) + """
 - **Hauptprobleme:**
     - Platzhalter-Beschreibungen (Zweck-Sektion unvollständig)
@@ -141,5 +143,5 @@ Nach einer automatisierten Analyse aller Factsheets wurden folgende Defizite ide
     print(f"Roadmap generated at {roadmap_file}")
 
 if __name__ == "__main__":
-    data = analyze()
-    generate_roadmap(data)
+    data, total = analyze()
+    generate_roadmap(data, total)


### PR DESCRIPTION
This PR updates the factsheet roadmap generation to be more accurate and automated. Previously, the total number of factsheets was a hardcoded estimate. Now, the `scripts/analyze_factsheets.py` script traverses the `factsheets/` directory to count how many tool-level `README.md` files actually exist. Additionally, a typo in the status quo section of the roadmap was corrected. `FACTSHEET_ROADMAP.md` has been regenerated to reflect these changes.

Fixes #245

---
*PR created automatically by Jules for task [17623451625052205846](https://jules.google.com/task/17623451625052205846) started by @chatelao*