### PR TITLE
Bioinformatics: Implement Ball-and-Stick Model for PyMOL and Jmol

### DIFF
--- a/factsheets/bioinformatik/jmol/README.md
+++ b/factsheets/bioinformatik/jmol/README.md
@@ -32,6 +32,7 @@ jmol -n -g 100x100 -J "load $caffeine; write image hello.png"
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
 
 - `molecule.pdb`
+- `ball_and_stick.jmol`: Skript für ein "Ball and Stick"-Modell mit O/N-Farbcodierung.
 - `test.cif`
 - `test.mol`
 - `sample1.pdb`

--- a/factsheets/bioinformatik/jmol/examples/ball_and_stick.jmol
+++ b/factsheets/bioinformatik/jmol/examples/ball_and_stick.jmol
@@ -1,0 +1,18 @@
+# Jmol Ball and Stick Model
+# Load molecule if not already loaded (standard path for example)
+load factsheets/bioinformatik/jmol/examples/molecule.pdb
+
+# Ball and stick style
+wireframe 0.15
+spacefill 0.25
+
+# Show multiple bonds
+set bondvalence on
+
+# Standard CPK colors (O: red, N: blue)
+color oxygen red
+color nitrogen blue
+color carbon green
+
+# Optional: label atoms
+# label %a

--- a/factsheets/bioinformatik/pymol/README.md
+++ b/factsheets/bioinformatik/pymol/README.md
@@ -36,7 +36,8 @@ pymol.finish_launching()
 Die folgenden Beispieldaten befinden sich im Ordner `examples/`:
 
 - `protein.pdb`
-- `script.pml`
+- `script.pml`: Basis-Skript zur Darstellung von Sticks.
+- `ball_and_stick.pml`: Erweitertes Skript für ein "Ball and Stick"-Modell mit O/N-Farbcodierung.
 - `ex1.pdb`
 - `ex2.pdb`
 - `ex3.pdb`

--- a/factsheets/bioinformatik/pymol/examples/ball_and_stick.pml
+++ b/factsheets/bioinformatik/pymol/examples/ball_and_stick.pml
@@ -1,0 +1,21 @@
+# Ball and Stick Model
+load protein.pdb
+hide all
+
+# Show as stick and ball
+show sticks
+show spheres
+set sphere_scale, 0.25
+
+# Enable double bonds
+set valence, 1
+
+# Colors: red for O, blue for N
+color red, elem o
+color blue, elem n
+
+# Default color for carbon (green in the user's image for some, pink for others)
+color green, elem c
+
+# Center the view
+zoom

--- a/factsheets/bioinformatik/pymol/examples/script.pml
+++ b/factsheets/bioinformatik/pymol/examples/script.pml
@@ -1,2 +1,8 @@
 load protein.pdb
+hide all
 show sticks
+show spheres
+set sphere_scale, 0.25
+set valence, 1
+color red, elem o
+color blue, elem n


### PR DESCRIPTION
This change introduces a "ball and stick" visualization style for molecular structures in PyMOL and Jmol, fulfilling the user request for specific atom coloring (red O, blue N) and bond representation. It includes new example scripts and updated documentation.

Fixes #256

---
*PR created automatically by Jules for task [11932278678184599306](https://jules.google.com/task/11932278678184599306) started by @chatelao*